### PR TITLE
Fix crash in ratios_on_models when ncols > 1 

### DIFF
--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -568,6 +568,11 @@ class LineRatioPlot(PlotBase):
         if type(self._axis) is not np.ndarray:
             self._axis = np.array([self._axis])
 
+        #When using ncols>1, either the index needs to be 2-d or the axis array needs to be 1-d.
+        #This takes the second approach:
+        if len(self._axis.shape) > 1:
+            self._axis = self._axis.flatten()
+
         #if self._modelnaxis==2:
         #     ax1='1'
         #     ax2='2'


### PR DESCRIPTION
When running the `ratios_on_models` function with the `ncols` argument, the program crashes with `numpy.ndarray object has no set_ylabel() method`. 

I tracked that down to the kwarg `index` passed by `ratios_on_models` to `_plot_no_wcs`, which is a one-dimensional index. However, `plt.subplots` (on line 563) returns a 2-d array of axes when there are two dimensions of subplots. Later, when indexing the `self._axis` array, the program would crash when expecting an axis and getting an entire numpy array (of axes) instead.

I propose to fix this by flattening the `self._axis` array if the program notices it is two dimensional. This seems to produce reasonable results:
![ratios_columns_demo_for_github](https://user-images.githubusercontent.com/4166159/90058992-7bf17d00-dcb0-11ea-9521-2db255ee79be.png)

