### PR TITLE
Allow custom FUV units when plotting

### DIFF
--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -616,7 +616,7 @@ class LineRatioPlot(PlotBase):
                 #self._wcs_colorbar(im,self._axis[axidx])
     #todo: allow unit conversion to cgs or Draine
         if kwargs_opts['yaxis_unit'] is not None:
-            yunit = kwargs_opts['yaxis_units']
+            yunit = kwargs_opts['yaxis_unit']
             temp_y= y * (u.erg/u.cm**2/u.s)
             y = temp_y.to(yunit).value
 

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -504,7 +504,8 @@ class LineRatioPlot(PlotBase):
                        'image':True,
                        'colorbar': False,
                        'contours': True,
-                       'label': False
+                       'label': False,
+                       'yaxis_unit': None
                        }
 
         kwargs_contour = {'levels': None, 
@@ -614,7 +615,12 @@ class LineRatioPlot(PlotBase):
                 self._figure.colorbar(im,ax=self._axis[axidx])
                 #self._wcs_colorbar(im,self._axis[axidx])
     #todo: allow unit conversion to cgs or Draine
-    
+        if kwargs_opts['yaxis_unit'] is not None:
+            yunit = kwargs_opts['yaxis_units']
+            temp_y= y * (u.erg/u.cm**2/u.s)
+            y = temp_y.to(yunit).value
+
+
         if kwargs_opts['contours']:
             if kwargs_contour['levels'] is None:
                 # Figure out some autolevels 

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -50,7 +50,7 @@ class LineRatioPlot(PlotBase):
 
     To manage the plots, the methods in this class take keywords (\*\*kwargs) that turn on or off various options, specify plot units, or map to matplotlib's :meth:`~matplotlib.axes.Axes.plot`, :meth:`~matplotlib.axes.Axes.imshow`, :meth:`~matplotlib.axes.Axes.contour` keywords.  The methods have reasonable defaults, so try them with no keywords to see what they do before modifying keywords.
 
-     * *units* (``str`` or :class:`astropy.units.Unit`) data units to use in the plot. This can be either a string such as, 'cm^-3' or 'Habing', or it can be an :class:`astropy.units.Unit`.  Data will be converted to the desired unit.   Note these are **not** the axis units, but the image data units.  Modifying axis units is not yet implemented.
+     * *units* (``str`` or :class:`astropy.units.Unit`) data units to use in the plot. This can be either a string such as, 'cm^-3' or 'Habing', or it can be an :class:`astropy.units.Unit`.  Data will be converted to the desired unit.   Note these are **not** the axis units, but the image data units.  Modifying axis units is implemented via the `yaxis_unit` keyword. 
 
      * *image* (``bool``) whether or not to display the image map (imshow). 
 
@@ -79,6 +79,8 @@ class LineRatioPlot(PlotBase):
      * *vmin*  (``float``) Minimum value for colormap normalization
 
      * *vmax*  (``float``) Maximum value for colormap normalization
+    
+     * *yaxis_unit* (``str`` or :class: astropy.units.Unit) Y axis (FUV flux) units to use when plotting single pixel data, such as in `overlay_all_ratios` 
 
      The following keywords are available, but you probably won't touch.
 

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -80,7 +80,7 @@ class LineRatioPlot(PlotBase):
 
      * *vmax*  (``float``) Maximum value for colormap normalization
     
-     * *yaxis_unit* (``str`` or :class: astropy.units.Unit) Y axis (FUV flux) units to use when plotting single pixel data, such as in `overlay_all_ratios` 
+     * *yaxis_unit* (``str`` or :class:`astropy.units.Unit`) Y axis (FUV flux) units to use when plotting single pixel data, such as in :meth:`overlay_all_ratios` 
 
      The following keywords are available, but you probably won't touch.
 

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -597,8 +597,17 @@ class LineRatioPlot(PlotBase):
         x = 10**np.linspace(start=xstart, stop=xstop, num=_header['naxis'+ax1])
         locmaj = ticker.LogLocator(base=10.0, subs=(1.0, ),numticks=10)
         locmin = ticker.LogLocator(base=10.0, subs=np.arange(2, 10)*.1,numticks=10) 
+        
         xlab = _header['ctype'+ax1] + ' ['+_header['cunit'+ax1]+']'
-        ylab = _header['ctype'+ax2] + ' ['+_header['cunit'+ax2]+']'
+        #todo: allow unit conversion to cgs or Draine
+        if kwargs_opts['yaxis_unit'] is not None:
+            yunit = kwargs_opts['yaxis_unit']
+            temp_y= y * u.Unit(_header['cunit'+ax1])
+            y = temp_y.to(yunit).value
+            ylab = f"{_header['ctype'+ax2]} [{yunit}]"
+        else:
+            ylab = _header['ctype'+ax2] + ' ['+_header['cunit'+ax2]+']'
+        
         self._axis[axidx].set_ylabel(ylab)
         self._axis[axidx].set_xlabel(xlab)
 
@@ -614,12 +623,6 @@ class LineRatioPlot(PlotBase):
             if kwargs_opts['colorbar']:
                 self._figure.colorbar(im,ax=self._axis[axidx])
                 #self._wcs_colorbar(im,self._axis[axidx])
-    #todo: allow unit conversion to cgs or Draine
-        if kwargs_opts['yaxis_unit'] is not None:
-            yunit = kwargs_opts['yaxis_unit']
-            temp_y= y * (u.erg/u.cm**2/u.s)
-            y = temp_y.to(yunit).value
-
 
         if kwargs_opts['contours']:
             if kwargs_contour['levels'] is None:

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -599,13 +599,23 @@ class LineRatioPlot(PlotBase):
         locmin = ticker.LogLocator(base=10.0, subs=np.arange(2, 10)*.1,numticks=10) 
         
         xlab = _header['ctype'+ax1] + ' ['+_header['cunit'+ax1]+']'
-        #todo: allow unit conversion to cgs or Draine
+        
+        #allow unit conversion to cgs or Draine, for Y axis (FUV field):
         if kwargs_opts['yaxis_unit'] is not None:
-            yunit = kwargs_opts['yaxis_unit']
-            temp_y= y * u.Unit(_header['cunit'+ax2])
-            y = temp_y.to(yunit).value
+            yunit = kwargs_opts['yaxis_unit']  
+            # Get desired unit from arguments
+
+            temp_y= y * u.Unit(_header['cunit'+ax2])  
+            # Make FUV axis of the grid into a Quantity using the cunits from the grid header
+
+            y = temp_y.to(yunit).value  
+            # Convert the unit-aware grid to the desired units and set Y to the value (so it's no longer a Quantity)
+
             ylab = f"{_header['ctype'+ax2]} [{yunit}]"
+            # Set the y label appropriately.
+
         else:
+            # Don't do any conversions, instead just use units from grid
             ylab = _header['ctype'+ax2] + ' ['+_header['cunit'+ax2]+']'
         
         self._axis[axidx].set_ylabel(ylab)

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -602,7 +602,7 @@ class LineRatioPlot(PlotBase):
         #todo: allow unit conversion to cgs or Draine
         if kwargs_opts['yaxis_unit'] is not None:
             yunit = kwargs_opts['yaxis_unit']
-            temp_y= y * u.Unit(_header['cunit'+ax1])
+            temp_y= y * u.Unit(_header['cunit'+ax2])
             y = temp_y.to(yunit).value
             ylab = f"{_header['ctype'+ax2]} [{yunit}]"
         else:


### PR DESCRIPTION
Added a new `kwarg "yaxis_unit"` to `_plot_no_wcs`. This allows the user to pass `yaxis_unit=<unit>` to any of the plotting routines that use `_plot_no_wcs`, such as `overlay_all_ratios`, `ratios_on_models`, `reduced_chisq`, etc. 

Especially useful if your group is used to Habing or Draine units for FUV field instead of ergs per second per square cm!

Closes (at least part of) #3 (no option for X axis---as discussed)