### PR TITLE
Fix reference to ms.supported_lines

### DIFF
--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -56,7 +56,7 @@ class LineRatioPlot(PlotBase):
            :raises KeyError: if is id not in existing model intensities
         """
         ms = self._tool.modelset
-        if id not in ms.supported_lines["intensity label"]:
+        if id not in ms.supported_intensities["intensity label"]:
             raise KeyError(f"{id} is not in the ModelSet of your LineRatioFit")
 
         model = ms.get_models([id],model_type="intensity")


### PR DESCRIPTION
It appears that the `ModelSet` attribute `supported_lines` has been replaced by `supported_intensities`, so I have updated the reference to it in the `LineRatioPlot` module in order for the `LineRatioPlot().modelintensity()` function to work.