### PR TITLE
Fix for change in behavior in recent astropy

### DIFF
--- a/pdrtpy/tool/lineratiofit.py
+++ b/pdrtpy/tool/lineratiofit.py
@@ -779,7 +779,7 @@ Once the fit is done, :class:`~pdrtpy.plot.LineRatioPlot` can be used to view th
             thirdindex = 3
             fourthindex = 4
         rchi_min=np.amin(self._reduced_chisq.data,(firstindex,secondindex))
-        chi_min=np.amin(self._chisq,(firstindex,secondindex))
+        chi_min=np.amin(self._chisq.data,(firstindex,secondindex))
         gnxy = np.where(self._reduced_chisq==rchi_min)
         gi = gnxy[firstindex]
         ni = gnxy[secondindex]


### PR DESCRIPTION
Astropy 5.3.3 / numpy 1.24.4 triggers a strange error when CCDData is passed to np.min(). In older versions it would return a unitless number, but now it raises an exception. It is unclear what the expected behavior is, so I changed this line to pass the underlying array to numpy instead of the CCDData object. This now matches the previous line as well.

see also:
https://github.com/astropy/astropy/issues/15397