### PR TITLE
Chunked parallel submission for H2ExcitationFit (2.2x speedup)

### DIFF
--- a/goals/exfit_upgrade_summary.md
+++ b/goals/exfit_upgrade_summary.md
@@ -1,8 +1,9 @@
 # ExcitationFit Upgrade — Implementation Summary
 
-Branch: `excitationfit-upgrade`
-PR: #218
-Date completed: 2026-05-27
+| Branch | PR | Date |
+|---|---|---|
+| `excitationfit-upgrade` | #218 | 2026-05-27 |
+| `excitationfit-chunked` | #220 | 2026-05-27 |
 
 ---
 
@@ -54,7 +55,8 @@ fit.run(components=2)               # serial (default)
 
 Implementation uses `ProcessPoolExecutor` with:
 - `_init_excitation_worker` — builds the lmfit `Model` once per worker process
-- `_excitation_pixel_worker` — fits one pixel, returns parameter dict
+- `_excitation_pixel_worker` — fits one pixel, returns `(i, result)` tuple
+- `_excitation_chunk_worker` — fits a batch of pixels serially, returns list of `(i, result)` (see §3 below)
 
 **Pickling caveat:** lmfit's `Model` requires `func.__name__` to be set.
 `functools.partial` objects lack `__name__`, so it must be assigned manually
@@ -65,7 +67,40 @@ Two-component model uses `ref = max(a, b); model = ref + log10(1 + 10^(other−r
 to avoid overflow/underflow when the two temperature components differ by many
 dex.
 
-### 3. Benchmark script
+### 3. Chunked parallel submission (PR #220)
+
+The initial parallel implementation submitted one pixel per
+`ProcessPoolExecutor` task.  Per-task IPC overhead (~1–2 ms) exceeded per-pixel
+compute time (~10–13 ms) enough that parallel was slower than serial on the CenA
+map (~837 valid pixels).
+
+The fix: batch `chunk_size` pixels (default 32) into each task.  Each worker
+fits its chunk serially; IPC is paid once per chunk, not once per pixel.
+
+**New module-level function:** `_excitation_chunk_worker(indices, yr_chunk,
+sig_chunk, m1s, n1s, m2s, n2s)` — receives a list of pixel indices and
+`(n_lines, chunk_size)` data slices, returns `list[(i, ModelResult|None)]`.
+
+**New parameter:** `chunk_size=32` added to `run()`, threaded through
+`_run_pixel_fits` → `_run_pixel_fits_parallel`.  The progress bar now tracks
+valid pixels only (not the full map including masked pixels).
+
+**Benchmark results (CenA map, 837 valid pixels, 12 CPUs):**
+
+| Mode | Mean time | ms/pixel |
+|---|---|---|
+| Serial | 17.0 s | 6.4 ms |
+| Parallel `chunk_size=32` | 7.8 s | 2.9 ms |
+| **Speedup** | **2.2×** | |
+
+Correctness: median relative difference vs master reference = **0.00%** on all
+four parameters.
+
+**Chunk size guidance:** default 32 is a good starting point (chunk compute
+~320 ms >> IPC ~1–2 ms).  Larger chunks reduce overhead further but coarsen
+progress-bar granularity and may cause load imbalance on the last chunk.
+
+### 4. Benchmark script
 
 `scripts/benchmark_excitationfit.py` — times `H2ExcitationFit.run()` on the
 CenA 7-line H₂ dataset.  Key flags:
@@ -73,6 +108,7 @@ CenA 7-line H₂ dataset.  Key flags:
 ```
 --partition-method {ssr,pelt,both}   # compare algorithms
 --workers N                          # parallel workers
+--chunk-size N                       # pixels per parallel task (default 32)
 --runs N                             # repeated timing
 --save-reference FILE.npz            # save fitted maps for correctness checks
 --compare-reference FILE.npz         # diff current run against saved reference
@@ -84,20 +120,11 @@ CenA 7-line H₂ dataset.  Key flags:
 
 ### Parallel workers: overhead vs. speedup threshold
 
-On small maps (≤ ~800 valid pixels, 12 CPUs) the parallel path is **not
-faster** than serial.  Root cause: per-task IPC overhead (~1–2 ms) vs.
-lightweight lmfit compute (~10–13 ms per pixel) with one task submitted per
-pixel.  Measured: serial ~10.8 s, parallel ~16 s on CenA test data.
-
-Rule of thumb: **parallel helps only above ~5000 valid pixels** (where compute
-time per pixel amortises IPC cost).  The `workers` parameter is still correct to
-expose — it will matter for large JWST/ALMA maps.
-
-### Chunking not implemented
-
-`LineRatioFit` also submits one pixel per task.  Batching N pixels per
-`Executor` task would reduce IPC overhead and is the right next step for both
-tools.  Deferred — tracked here as a future option.
+With the original one-pixel-per-task approach, IPC overhead (~1–2 ms per task)
+exceeded per-pixel compute time enough that parallel was *slower* than serial on
+the CenA map.  The chunked submission (PR #220) fixed this: 2.2× speedup at 837
+valid pixels with `chunk_size=32`.  For very small maps (≲ 100 valid pixels) the
+process-pool startup cost may still dominate; serial remains the safe default.
 
 ### `_one_line` required by `excitationplot.py`
 
@@ -177,7 +204,7 @@ These items were discussed but deliberately left off this branch:
 
 | Item | Notes |
 |---|---|
-| **Chunked parallel submission** | Submit N pixels per task to amortise IPC overhead; threshold ~50–100 pixels/chunk |
+| **Chunked parallel submission** | ✅ Done (PR #220) — `chunk_size=32` default; 2.2× speedup on CenA map |
 | **Tikhonov / spatial regularisation** | Requires moving from per-pixel `minimize()` to a single joint minimisation with sparse Jacobian (Option 4 in `regularization.md`).  Per-pixel independence is a hard architectural barrier to regularisation. |
 | **`components=None` auto-selection** | Automatically choose 1 vs 2 components via AIC/BIC or F-test on the piecewise fit quality |
 | **More than 2 components** | Piecewise framework supports n breakpoints; lmfit model extension straightforward |
@@ -189,8 +216,8 @@ These items were discussed but deliberately left off this branch:
 
 | File | Change |
 |---|---|
-| `pdrtpy/tool/excitation.py` | Core implementation (new methods, `workers`, `partition_method`, log-sum-exp model, `_one_line` restore) |
+| `pdrtpy/tool/excitation.py` | Core implementation (new methods, `workers`, `chunk_size`, `partition_method`, log-sum-exp model, `_one_line` restore) |
 | `pyproject.toml` | Added `ruptures` to dependencies |
 | `uv.lock` | Updated (ruptures 1.1.10) |
-| `scripts/benchmark_excitationfit.py` | New benchmark script |
+| `scripts/benchmark_excitationfit.py` | Benchmark script (`--partition-method`, `--workers`, `--chunk-size`, `--runs`, `--save/compare-reference`) |
 | `scripts/bench_excitation_ref_master.npz` | Reference solution from master branch |

--- a/pdrtpy/tool/excitation.py
+++ b/pdrtpy/tool/excitation.py
@@ -103,6 +103,43 @@ def _excitation_pixel_worker(i, yr_i, sig_i, m1v, n1v, m2v, n2v):
         return i, None
 
 
+def _excitation_chunk_worker(indices, yr_chunk, sig_chunk, m1s, n1s, m2s, n2s):
+    """Fit a chunk of pixels in a worker process. Returns list of (i, result).
+
+    Each worker receives a contiguous slice of valid pixels so that IPC overhead
+    is paid once per chunk rather than once per pixel.  ``yr_chunk`` and
+    ``sig_chunk`` are shaped ``(n_lines, chunk_size)`` — the same column-major
+    layout as ``prep.yr``.  ``m1s``, ``n1s``, ``m2s``, ``n2s`` are 1-D arrays of
+    per-pixel initial guesses with length ``chunk_size``.
+    """
+    model, base_params, x, idx, fit_opr, fit_av, extinction_ratios, method, nan_policy = _excitation_worker_state
+    out = []
+    for k, i in enumerate(indices):
+        p = base_params.copy()
+        p["m1"].value = m1s[k]
+        p["n1"].value = n1s[k]
+        if "m2" in p:
+            p["m2"].value = m2s[k]
+            p["n2"].value = n2s[k]
+        try:
+            result = model.fit(
+                data=yr_chunk[:, k],
+                weights=1.0 / sig_chunk[:, k],
+                x=x,
+                params=p,
+                idx=idx,
+                fit_opr=fit_opr,
+                fit_av=fit_av,
+                extinction_ratio=extinction_ratios,
+                method=method,
+                nan_policy=nan_policy,
+            )
+            out.append((i, result))
+        except ValueError:
+            out.append((i, None))
+    return out
+
+
 # ── End module-level ─────────────────────────────────────────────────────────
 
 
@@ -291,12 +328,17 @@ class BaseExcitationFit(ToolBase):
             outperforms serial on maps with roughly 5 000 or more *valid* (unmasked)
             pixels.  On smaller maps the IPC overhead dominates and serial is faster.
 
-            A future optimisation would be to submit *chunks* of pixels per task
-            (each worker runs a mini serial loop over its chunk), paying the pickle
-            cost once per chunk rather than once per pixel.  This would make parallel
-            worthwhile at much smaller map sizes.  ``emcee`` fitting is excluded from
-            the parallel path regardless of this setting.
+            ``emcee`` fitting is excluded from the parallel path regardless of
+            this setting.
         :type workers: int or None
+        :param chunk_size: Number of pixels batched into each parallel task
+            (default: 32).  Each worker process fits ``chunk_size`` pixels
+            serially, so IPC serialisation overhead is paid once per chunk
+            rather than once per pixel.  Larger values reduce overhead further
+            but coarsen progress-bar granularity and may cause load imbalance
+            on the last chunk.  Ignored when ``workers`` is ``None`` or when
+            the fitting method is ``'emcee'``.
+        :type chunk_size: int
         """
         # @todo what happens if e.g., fit_av=True and init_av !=0 ?
         kwargs_opts = {
@@ -308,6 +350,7 @@ class BaseExcitationFit(ToolBase):
             "init_opr": 3.0,
             "init_av": 0.0,
             "workers": None,
+            "chunk_size": 32,
             "partition_method": "ssr",
             # for emcee
             "burn": 0,
@@ -1282,6 +1325,7 @@ class BaseExcitationFit(ToolBase):
         via :class:`~concurrent.futures.ProcessPoolExecutor`.
         """
         workers = kwargs.pop("workers", None)
+        chunk_size = kwargs.pop("chunk_size", 32)
         total = prep.total
         fmdata = np.empty(total, dtype=object)
         fm_mask = np.full(total, False)
@@ -1300,7 +1344,9 @@ class BaseExcitationFit(ToolBase):
         nan_policy = kwargs["nan_policy"]
 
         if workers is not None and method != "emcee":
-            return self._run_pixel_fits_parallel(prep, fit_opr, fit_av, method, nan_policy, workers, verbose)
+            return self._run_pixel_fits_parallel(
+                prep, fit_opr, fit_av, method, nan_policy, workers, chunk_size, verbose
+            )
 
         progress = kwargs.pop("progress", True) if total > 1 else False
         emcee_kwargs = (
@@ -1357,8 +1403,16 @@ class BaseExcitationFit(ToolBase):
 
         return fmdata, fm_mask, count
 
-    def _run_pixel_fits_parallel(self, prep, fit_opr, fit_av, method, nan_policy, workers, verbose):
-        """Parallel pixel fitting via ProcessPoolExecutor."""
+    def _run_pixel_fits_parallel(self, prep, fit_opr, fit_av, method, nan_policy, workers, chunk_size, verbose):
+        """Parallel pixel fitting via ProcessPoolExecutor with chunked submission.
+
+        Pixels are batched into groups of ``chunk_size`` before being submitted
+        to :class:`~concurrent.futures.ProcessPoolExecutor`.  Each worker fits
+        its chunk serially, so inter-process serialisation cost is paid once per
+        chunk rather than once per pixel.  This makes parallel execution
+        worthwhile at much smaller map sizes than the one-pixel-per-task
+        approach.
+        """
         total = prep.total
         fmdata = np.empty(total, dtype=object)
         fm_mask = np.full(total, False)
@@ -1387,32 +1441,44 @@ class BaseExcitationFit(ToolBase):
             nan_policy,
         )
 
+        # Collect valid pixel indices; mask the rest immediately.
+        valid = [i for i in range(total) if np.isfinite(prep.yr[:, i]).all() and np.isfinite(prep.sig[:, i]).all()]
+        for i in range(total):
+            if not (np.isfinite(prep.yr[:, i]).all() and np.isfinite(prep.sig[:, i]).all()):
+                fm_mask[i] = True
+
+        # Partition valid indices into chunks.
+        chunks = [valid[s : s + chunk_size] for s in range(0, len(valid), chunk_size)]
+
         futures = {}
         with ProcessPoolExecutor(max_workers=n_workers, initializer=_init_excitation_worker, initargs=init_args) as ex:
-            for i in range(total):
-                if not (np.isfinite(prep.yr[:, i]).all() and np.isfinite(prep.sig[:, i]).all()):
-                    fm_mask[i] = True
-                    continue
-                m1v = prep.slopecold[i]
-                n1v = prep.intcold[i]
-                m2v = prep.slopehot[i] if self._numcomponents == 2 else None
-                n2v = prep.inthot[i] if self._numcomponents == 2 else None
-                futures[ex.submit(_excitation_pixel_worker, i, prep.yr[:, i], prep.sig[:, i], m1v, n1v, m2v, n2v)] = i
+            for chunk in chunks:
+                yr_c = prep.yr[:, chunk]
+                sig_c = prep.sig[:, chunk]
+                m1s = prep.slopecold[chunk]
+                n1s = prep.intcold[chunk]
+                if self._numcomponents == 2:
+                    m2s = prep.slopehot[chunk]
+                    n2s = prep.inthot[chunk]
+                else:
+                    m2s = n2s = [None] * len(chunk)
+                futures[ex.submit(_excitation_chunk_worker, chunk, yr_c, sig_c, m1s, n1s, m2s, n2s)] = chunk
 
-            with get_progress_bar(True, total, leave=True, position=0) as pbar:
+            n_valid = len(valid)
+            with get_progress_bar(True, n_valid, leave=True, position=0) as pbar:
                 for fut in as_completed(futures):
-                    i, result = fut.result()
-                    if result is None:
-                        fm_mask[i] = True
-                        self._excount += 1
-                    else:
-                        fmdata[i] = result
-                        if result.success:
-                            count += 1
-                        else:
+                    for i, result in fut.result():
+                        if result is None:
                             fm_mask[i] = True
-                            self._badfit += 1
-                    pbar.update(1)
+                            self._excount += 1
+                        else:
+                            fmdata[i] = result
+                            if result.success:
+                                count += 1
+                            else:
+                                fm_mask[i] = True
+                                self._badfit += 1
+                        pbar.update(1)
 
         return fmdata, fm_mask, count
 

--- a/scripts/benchmark_excitationfit.py
+++ b/scripts/benchmark_excitationfit.py
@@ -133,6 +133,8 @@ def _timed_run(method: str, measurements: list, args: argparse.Namespace, log: l
     run_kwargs = {"components": args.components, "partition_method": method}
     if args.workers is not None:
         run_kwargs["workers"] = args.workers
+    if args.chunk_size is not None:
+        run_kwargs["chunk_size"] = args.chunk_size
 
     elapsed_times = []
     last_fit = None
@@ -254,6 +256,14 @@ def main() -> None:
         default=None,
         metavar="N",
         help="number of worker processes (-1 = all CPUs, default: serial)",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        "-k",
+        type=int,
+        default=None,
+        metavar="N",
+        help="pixels per parallel task (default: 32); ignored when --workers is not set",
     )
     parser.add_argument(
         "--partition-method",


### PR DESCRIPTION
## Summary

- Replaces one-pixel-per-task parallel submission with chunked batching: each worker process fits `chunk_size` pixels (default 32) serially, paying IPC serialisation overhead once per chunk instead of once per pixel.
- Adds `_excitation_chunk_worker` module-level function alongside the existing `_excitation_pixel_worker`.
- Adds `chunk_size` parameter to `run()` (default 32), threaded through `_run_pixel_fits` → `_run_pixel_fits_parallel`.
- Adds `--chunk-size` flag to `scripts/benchmark_excitationfit.py`.
- Updates `run()` docstring to remove the "future optimisation" note (now implemented) and document `chunk_size`.

## Benchmark results (CenA 7-line H₂ map, 837 valid pixels, 12 CPUs)

| Mode | Mean time | ms/pixel |
|---|---|---|
| Serial | 17.0 s | 6.4 ms |
| Parallel `chunk_size=32` | 7.8 s | 2.9 ms |
| **Speedup** | **2.2×** | |

Correctness: median relative difference vs master reference = **0.00%** on all four parameters (tcold, ncold, thot, nhot).

## Test plan

- [x] `uv run pytest -n auto pdrtpy/tool/test/test_h2excitation.py` — 13 passed
- [x] Benchmark serial vs parallel (results above)
- [x] `--compare-reference` correctness check vs `bench_excitation_ref_master.npz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)