### PR TITLE
Convert docstrings from reST to NumPy style (issue #103)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ autosummary_generate = True
 
 autodoc_docstring_signature = True
 autodoc_default_options = {"members": None, "undoc-members": None}
+autoclass_content = "both"
 # Make sure the targets are unique
 autosectionlabel_prefix_document = True
 

--- a/docs/source/pdrtpy.tool.rst
+++ b/docs/source/pdrtpy.tool.rst
@@ -33,7 +33,7 @@ The base class of all tools.  Tools have a :meth:`~pdrtpy.tool.toolbase.ToolBase
 Excitation Diagram Fitting
 --------------------------
 
-:class:`~pdrtpy.tool.excitation.H2ExcitationFit` is a tool for fitting temperature, column density, and ortho-to-para ratio in :math:`H_2` excitation diagrams.  A two temperature model is assumed, and the fit will find :math:`T_{hot}, T_{cold}, N_{hot}(H_2), N_{cold}(H_2),` and optionally `A_v` or `OPR`.  The base class :class:`~pdrtpy.tool.excitation.ExcitationFit` can be used to create a tool to fit a different molecule.
+:class:`~pdrtpy.tool.excitation.H2ExcitationFit` is a tool for fitting temperature, column density, visual extinction, and ortho-to-para ratio in :math:`H_2` excitation diagrams.  With a two temperature model assumed, the fit will find :math:`T_{hot}, T_{cold}, N_{hot}(H_2), N_{cold}(H_2),` and optionally :math:`A_v` or :math:`OPR`.  The base class :class:`~pdrtpy.tool.excitation.ExcitationFit` can be used to create a tool to fit a different molecule.  Single temperature fitting is also available.
 
 Similarly, there are tools to fit :math:`^{12}CO, ^{13}CO, ^{12}C^{18}O, ^{13}C^{18}O, {\rm and}~ CH^{+}`.
 
@@ -42,8 +42,8 @@ Similarly, there are tools to fit :math:`^{12}CO, ^{13}CO, ^{12}C^{18}O, ^{13}C^
    :undoc-members:
    :show-inheritance:
 
-LineRatioFit
-------------
+Fitting Line Ratios For Density and Radiation Field
+---------------------------------------------------
 
 :class:`~pdrtpy.tool.lineratiofit.LineRatioFit` is a tool for determining photodissociation region external radiation field and hydrogen nucleus density (commonly given as :math:`G_0` and :math:`n`) from measured spectral line intensity ratios.
 

--- a/pdrtpy/measurement.py
+++ b/pdrtpy/measurement.py
@@ -29,36 +29,32 @@ class Measurement(CCDData):
 
     Typically, Measurements will be instantiated from a FITS file by using the the :func:`read` or :func:`make_measurement` methods.  For a list of recognized spectral line identifiers, see :meth:`~pdrtpy.modelset.Modelset.supported_lines`.
 
-    :param data:  The actual data contained in this :class:`Measurement` object.
-        Note that the data will always be saved by *reference*, so you should
-        make a copy of the ``data`` before passing it in if that's the desired
-        behavior.
-    :type data: :class:`numpy.ndarray`-like
+    Parameters
+    ----------
+    data : array-like
+        The actual data. Note that data is saved by *reference*, so make a
+        copy before passing if needed.
+    uncertainty : :class:`~astropy.nddata.StdDevUncertainty`, :class:`~astropy.nddata.VarianceUncertainty`, :class:`~astropy.nddata.InverseVariance`, or :class:`numpy.ndarray`
+        Uncertainties on the data. If a :class:`numpy.ndarray`, it is stored
+        as :class:`~astropy.nddata.StdDevUncertainty`. Required.
+    unit : :class:`astropy.units.Unit` or str
+        The units of the data. Required.
+    identifier : str
+        A string indicating what this is an observation of, e.g., ``"CO_10"`` for CO(1-0).
+    title : str, optional
+        A formatted string (e.g., LaTeX) for plotting. r-strings are accepted,
+        e.g., ``r'$^{13}$CO(3-2)'`` gives :math:`^{13}{\rm CO(3-2)}`.
+    bmaj : :class:`astropy.units.Quantity`, optional
+        Beam major axis diameter. Converted to degrees for FITS header storage.
+    bmin : :class:`astropy.units.Quantity`, optional
+        Beam minor axis diameter. Converted to degrees for FITS header storage.
+    bpa : :class:`astropy.units.Quantity`, optional
+        Beam position angle. Converted to degrees for FITS header storage.
 
-    :param uncertainty: Uncertainties on the data. If the uncertainty is a :class:`numpy.ndarray`, it assumed to be, and stored as, a :class:`astropy.nddata.StdDevUncertainty`.  Required.
-    :type uncertainty: :class:`astropy.nddata.StdDevUncertainty`, \
-            :class:`astropy.nddata.VarianceUncertainty`, \
-            :class:`astropy.nddata.InverseVariance` or :class:`numpy.ndarray`
-
-    :param unit: The units of the data.  Required.
-    :type unit: :class:`astropy.units.Unit` or str
-
-    :param identifier: A string indicating what this is an observation of, e.g., "CO_10" for CO(1-0)
-    :type identifier: str
-
-    :param title: A formatted string (e.g., LaTeX) describing this observation that can be used for plotting. Python r-strings are accepted, e.g., r'$^{13}$CO(3-2)'  would give :math:`^{13}{\rm CO(3-2)}`.
-    :type title: str
-
-    :param bmaj: [optional] beam major axis diameter. This will be converted to degrees for storage in FITS header
-    :type  bmaj: :class:`astropy.units.Quantity`
-
-    :param bmin: [optional] beam minor axis diameter. This will be converted to degrees for storage in FITS header
-    :type  bmin: :class:`astropy.units.Quantity`
-
-    :param bpa: [optional] beam position angle. This will be converted to degrees for storage in FITS header
-    :type  bpa: :class:`astropy.units.Quantity`
-
-    :raises TypeError: if beam parameters are not Quantities
+    Raises
+    ------
+    TypeError
+        If beam parameters are not Quantities.
 
     Measurements can also be instantiated by the **read(\\*args, \\**kwargs)**,
     to create an Measurement instance based on a ``FITS`` file.
@@ -142,31 +138,39 @@ class Measurement(CCDData):
 
     @staticmethod
     def make_measurement(datafile, error, outfile, rms=None, masknan=True, overwrite=False, unit="adu"):
-        """Create a FITS files with 2 HDUS, the first being the datavalue and the 2nd being
-        the data uncertainty. This format makes allows the resulting file to be read into the underlying :class:'~astropy.nddata.CCDData` class.
+        """Create a FITS file with 2 HDUs: the first containing the data, the second containing the uncertainty.
 
-        :param datafile: The FITS file containing the data as a function of spatial coordinates
-        :type datafile: str
-        :param error: The errors on the data Possible values for error are:
+        This format allows the resulting file to be read by the underlying
+        :class:`~astropy.nddata.CCDData` class.
 
-             - a filename with the same shape as datafile containing the error values per pixel
-             - a percentage value 'XX%' must have the "%" symbol in it
-             - 'rms' meaning use the rms parameter if given, otherwise look for the RMS keyword in the FITS header of the datafile
+        Parameters
+        ----------
+        datafile : str
+            The FITS file containing the data as a function of spatial coordinates.
+        error : str
+            The errors on the data. Possible values:
 
-        :type error: str
-        :param outfile: The output file to write the result in (FITS format)
-        :type outfile: str
-        :param rms:  If error == 'rms', this value may give the rms in same units as data (e.g 'erg s-1 cm-2 sr-1').
-        :type rms: float or :class:`astropy.units.Unit`
-        :param masknan: Whether to mask any pixel where the data or the error is NaN. Default:true
-        :type masknan: bool
-        :param overwrite: If `True`, overwrite the output file if it exists. Default: `False`.
-        :type overwrite: bool
-        :param unit: Intensity unit to use for the data, this will override BUNIT in header if present.
-        :type unit: :class:`astropy.units.Unit` or str
+             - a filename with the same shape as datafile containing per-pixel errors
+             - a percentage string ``'XX%'`` (must include the ``%`` symbol)
+             - ``'rms'``: use the ``rms`` parameter if given, otherwise look for the RMS keyword in the FITS header
 
-        :raises Exception: on various FITS header issues
-        :raises OSError: if `overwrite` is `False` and the output file exists.
+        outfile : str
+            The output FITS file to write the result to.
+        rms : float or :class:`astropy.units.Unit`, optional
+            If ``error == 'rms'``, the rms value in the same units as the data (e.g. ``'erg s-1 cm-2 sr-1'``).
+        masknan : bool, optional
+            Whether to mask any pixel where the data or error is NaN. Default: True.
+        overwrite : bool, optional
+            If True, overwrite the output file if it exists. Default: False.
+        unit : :class:`astropy.units.Unit` or str, optional
+            Intensity unit for the data; overrides BUNIT in the header if present.
+
+        Raises
+        ------
+        Exception
+            On various FITS header issues.
+        OSError
+            If ``overwrite`` is False and the output file exists.
 
         Example usage:
 
@@ -229,17 +233,21 @@ class Measurement(CCDData):
 
     @property
     def value(self):
-        """Return the underlying data array
+        """Return the underlying data array.
 
-        :rtype: :class:`numpy.ndarray`
+        Returns
+        -------
+        :class:`numpy.ndarray`
         """
         return self.data
 
     @property
     def error(self):
-        """Return the underlying error array
+        """Return the underlying error array.
 
-        :rtype: :class:`numpy.ndarray`
+        Returns
+        -------
+        :class:`numpy.ndarray`
         """
         if self.uncertainty is None:
             return None
@@ -247,9 +255,11 @@ class Measurement(CCDData):
 
     @property
     def SN(self):
-        """Return the signal to noise ratio (value/error)
+        """Return the signal to noise ratio (value/error).
 
-        :rtype: :class:`numpy.ndarray`
+        Returns
+        -------
+        :class:`numpy.ndarray`
         """
         if self.uncertainty is None:
             return None
@@ -257,18 +267,22 @@ class Measurement(CCDData):
 
     @property
     def id(self):
-        """Return the string ID of this measurement, e.g., CO_10
+        """Return the string ID of this measurement, e.g., ``CO_10``.
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         return self._identifier
 
     @id.setter
     def id(self, value):
-        """Set the string ID of this measurement, e.g., CO_10
+        """Set the string ID of this measurement, e.g., ``CO_10``.
 
-        :param value: the identifier
-        :type value: str
+        Parameters
+        ----------
+        value : str
+            The identifier.
         """
         self._identifier = value
 
@@ -281,36 +295,49 @@ class Measurement(CCDData):
             return None
 
     def is_ratio(self):
-        """Indicate if this `Measurement` is a ratio..
-        This method looks for the '/' past the first character  of the` Measurement` *identifier*, such as "CII_158/CO_32"
-        See also pdrutils.is_ratio(string)
+        """Indicate if this Measurement is a ratio.
 
-        :returns: True if the Measurement is a ratio, False otherwise
-        :rtype: bool"""
+        Looks for ``'/'`` past the first character of the identifier, e.g. ``"CII_158/CO_32"``.
+        See also :func:`~pdrtpy.utils.helpers.is_ratio`.
+
+        Returns
+        -------
+        bool
+            True if the Measurement is a ratio, False otherwise.
+        """
         return utils.is_ratio(self.id)  # pdrutils method
 
     @property
     def title(self):
-        """A formatted title (e.g., LaTeX) that can be in plotting.
+        """A formatted title (e.g., LaTeX) that can be used in plotting.
 
-        :rtype: str or None
+        Returns
+        -------
+        str or None
         """
         return self._title
 
     @property
     def filename(self):
-        """The FITS file that created this measurement, or None if it didn't originate from a file
+        """The FITS file that created this measurement, or None if it didn't originate from a file.
 
-        :rtype: str or None
+        Returns
+        -------
+        str or None
         """
         return self._filename
 
     def write(self, filename, **kwd):
-        """Write this Measurement to a FITS file with value in 1st HDU and error in 2nd HDU. See :meth:`astropy.nddata.CCDData.write`.
+        """Write this Measurement to a FITS file with value in 1st HDU and error in 2nd HDU.
 
-        :param filename:  Name of file.
-        :type filename: str
-        :param kwd: All additional keywords are passed to :py:mod:`astropy.io.fits`
+        See :meth:`astropy.nddata.CCDData.write`.
+
+        Parameters
+        ----------
+        filename : str
+            Name of file.
+        **kwd
+            All additional keywords are passed to :py:mod:`astropy.io.fits`.
         """
         hdu = self.to_hdu()
         hdu.writeto(filename, **kwd)
@@ -331,28 +358,35 @@ class Measurement(CCDData):
         )
 
     def get_pixel(self, world_x, world_y):
-        """Return the nearest pixel coordinates to the input world coordinates
+        """Return the nearest pixel coordinates to the input world coordinates.
 
-        :param world_x: The horizontal world coordinate
-        :type world_x: float
-        :param world_y: The vertical world coordinate
-        :type world_y: float
+        Parameters
+        ----------
+        world_x : float
+            The horizontal world coordinate.
+        world_y : float
+            The vertical world coordinate.
         """
         if self.wcs is None:
             raise Exception(f"No wcs in this Measurement {self.id}")
         return tuple(np.round(self.wcs.world_to_pixel_values(world_x, world_y)).astype(int))
 
     def get(self, world_x, world_y, log=False):
-        """Get the value(s) at the give world coordinates
+        """Get the value(s) at the given world coordinates.
 
-        :param world_x: the x value in world units of naxis1
-        :type world_x: float or array-like
-        :param world_y: the y value in world units of naxis2
-        :type world_y: float or array-lke
-        :param log: True if the input coords are logarithmic Default:False
-        :type log: bool
-        :returns: The value(s) of the Measurement at input coordinates
-        :rtype: float
+        Parameters
+        ----------
+        world_x : float or array-like
+            The x value in world units of naxis1.
+        world_y : float or array-like
+            The y value in world units of naxis2.
+        log : bool, optional
+            True if the input coords are logarithmic. Default: False.
+
+        Returns
+        -------
+        float
+            The value(s) of the Measurement at input coordinates.
         """
         if log:
             return float(self._interp_log((world_x, world_y)))
@@ -368,11 +402,14 @@ class Measurement(CCDData):
         )
 
     def _modify_id(self, other, op):
-        """Handle ID string for arithmetic operations with Measurements or numbers
-        :param other: a Measurement or number
-        :type other: :class:`Measurement` or number
-        :param op: descriptive string of operation, e.g. "+", "*"
-        :type op: str
+        """Handle ID string for arithmetic operations with Measurements or numbers.
+
+        Parameters
+        ----------
+        other : :class:`Measurement` or number
+            A Measurement or number.
+        op : str
+            Descriptive string of operation, e.g. ``"+"`` or ``"*"``.
         """
         if getattr(other, "id", None) is not None:
             return self.id + op + other.id
@@ -407,10 +444,12 @@ class Measurement(CCDData):
         return ""
 
     def add(self, other):
-        """Add this Measurement to another, propagating errors, units,  and updating identifiers.  Masks are logically or'd.
+        """Add this Measurement to another, propagating errors, units, and updating identifiers. Masks are logically or'd.
 
-        :param other: a Measurement or number to add
-        :type other: :class:`Measurement` or number
+        Parameters
+        ----------
+        other : :class:`Measurement` or number
+            A Measurement or number to add.
         """
         # need to do tricky stuff to preserve unit propogation.
         # super().add() does not work because it instantiates a Measurement
@@ -425,10 +464,12 @@ class Measurement(CCDData):
         return z
 
     def subtract(self, other):
-        """Subtract another Measurement from this one, propagating errors, units,  and updating identifiers.  Masks are logically or'd.
+        """Subtract another Measurement from this one, propagating errors, units, and updating identifiers. Masks are logically or'd.
 
-        :param other: a Measurement or number to subtract
-        :type other: :class:`Measurement` or number
+        Parameters
+        ----------
+        other : :class:`Measurement` or number
+            A Measurement or number to subtract.
         """
         z = CCDData.subtract(self, other, handle_mask=np.logical_or, handle_meta="first_found")
         z = Measurement(z, unit=z._unit)
@@ -437,10 +478,12 @@ class Measurement(CCDData):
         return z
 
     def multiply(self, other):
-        """Multiply this Measurement by another, propagating errors, units,  and updating identifiers.  Masks are logically or'd.
+        """Multiply this Measurement by another, propagating errors, units, and updating identifiers. Masks are logically or'd.
 
-        :param other: a Measurement or number to multiply
-        :type other: :class:`Measurement` or number
+        Parameters
+        ----------
+        other : :class:`Measurement` or number
+            A Measurement or number to multiply.
         """
         z = CCDData.multiply(self, other, handle_mask=np.logical_or, handle_meta="first_found")
         z = Measurement(z, unit=z._unit)
@@ -449,10 +492,12 @@ class Measurement(CCDData):
         return z
 
     def divide(self, other):
-        """Divide this Measurement by another, propagating errors, units,  and updating identifiers.  Masks are logically or'd.
+        """Divide this Measurement by another, propagating errors, units, and updating identifiers. Masks are logically or'd.
 
-        :param other: a Measurement or number to divide by
-        :type other: :class:`Measurement` or number
+        Parameters
+        ----------
+        other : :class:`Measurement` or number
+            A Measurement or number to divide by.
         """
         z = CCDData.divide(self, other, handle_mask=np.logical_or, handle_meta="first_found")
         z = Measurement(z, unit=z._unit)
@@ -462,8 +507,11 @@ class Measurement(CCDData):
 
     def is_single_pixel(self):
         """Is this Measurement a single value?
-        :returns: True if a single value (pixel)
-        :rtype: bool
+
+        Returns
+        -------
+        bool
+            True if a single value (pixel).
         """
         return self.data.size == 1
 
@@ -534,13 +582,24 @@ class Measurement(CCDData):
 
         The table must specify the units of each column, e.g. a unit row in the header for IPAC format.  Leave column entry blank if unitless.  Units of value and error should be the same or conformable. Units must be transformable to a valid astropy.unit.Unit.
 
-        :param filename: Name of table file.
-        :type filename: str
-        :param format: `Astropy Table format. <https://docs.astropy.org/en/stable/io/unified.html#built-in-readers-writers>`_ e.g., ascii, ipac, votable. Default is `IPAC format <https://docs.astropy.org/en/stable/api/astropy.io.ascii.Ipac.html#astropy.io.ascii.Ipac>`_
-        :param array: Controls whether a list of Measurements or a single Measurement is returned. If `array` is True,  one Measurement instance will be created for each row in the table and a Python list of Measurements will be returned.  If `array` is False,  one Measurement containing all the points in the `data` member will be returned. If `array` is False, the *identifier* and beam parameters of the first row will be used. If feeding the return value to a plot method such as :meth:`~pdrtpy.plot.modelplot.ModelPlot.phasespace`, choose `array=False`. Default:False.
-        :type array: bool
+        Parameters
+        ----------
+        filename : str
+            Name of table file.
+        format : str, optional
+            `Astropy Table format <https://docs.astropy.org/en/stable/io/unified.html#built-in-readers-writers>`_,
+            e.g., ``ascii``, ``ipac``, ``votable``. Default is
+            `IPAC format <https://docs.astropy.org/en/stable/api/astropy.io.ascii.Ipac.html#astropy.io.ascii.Ipac>`_.
+        array : bool, optional
+            If True, one Measurement is created per table row and a list is returned.
+            If False, one Measurement containing all data points is returned, using
+            the identifier and beam parameters of the first row.
+            For :meth:`~pdrtpy.plot.modelplot.ModelPlot.phasespace`, use ``array=False``.
+            Default: False.
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement` or list of :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement` or list of :class:`~pdrtpy.measurement.Measurement`
         """
         # @todo support input of a astropy.Table directly
         t = Table.read(filename, format=format)
@@ -613,49 +672,40 @@ class Measurement(CCDData):
 def fits_measurement_reader(
     filename, hdu=0, unit=None, hdu_mask="MASK", hdu_flags=None, key_uncertainty_type="UTYPE", **kwd
 ):
-    """FITS file reader for Measurement class, which will be called by :meth:`Measurement.read`.
+    """FITS file reader for Measurement class, called by :meth:`Measurement.read`.
 
-    :param filename: Name of FITS file.
-    :type filename: str
+    Parameters
+    ----------
+    filename : str
+        Name of FITS file.
+    identifier : str, optional
+        String indicating what this is an observation of, e.g., ``"CO_10"`` for CO(1-0).
+    squeeze : bool, optional
+        If True, remove single dimension axes from the input image. Default: True.
+    hdu : int, optional
+        FITS extension from which Measurement should be initialized. If zero
+        and no data in the primary extension, searches for the first extension
+        with data. Default: 0.
+    unit : :class:`astropy.units.Unit`, optional
+        Units of the image data. If provided and BUNIT is in the header, this
+        argument takes precedence. Default: None.
+    hdu_uncertainty : str or None, optional
+        FITS extension from which the uncertainty should be initialized.
+        If the extension does not exist, uncertainty is ``None``. Default: ``'UNCERT'``.
+    hdu_mask : str or None, optional
+        FITS extension from which the mask should be initialized.
+        If the extension does not exist, mask is ``None``. Default: ``'MASK'``.
+    hdu_flags : str or None, optional
+        Currently not implemented. Default: None.
+    key_uncertainty_type : str, optional
+        Header key name where the uncertainty class name is stored. Default: ``'UTYPE'``.
+    **kwd
+        Additional keyword parameters passed to the FITS reader in :mod:`astropy.io.fits`.
 
-    :param identifier: string indicating what this is an observation of, e.g., "CO_10" for CO(1-0)
-    :type identifier: str
-
-    :param squeeze: If ``True``, remove single dimension axes from the input image. Default: ``True``
-    :type squeeze: bool
-
-    :param hdu: FITS extension from which Measurement should be initialized.
-         If zero and and no data in the primary extension, it will
-         search for the first extension with data. The header will be
-         added to the primary header.  Default is 0.
-    :type hdu: int, optional
-
-    :type unit: :class:`astropy.units.Unit`, optional
-    :param unit:
-         Units of the image data. If this argument is provided and there is a
-         unit for the image in the FITS header (the keyword ``BUNIT`` is used
-         as the unit, if present), this argument is used for the unit.
-         Default is ``None``.
-
-    :type hdu_uncertainty: str or None, optional
-    :param hdu_uncertainty: FITS extension from which the uncertainty
-         should be initialized. If the extension does not exist the
-         uncertainty of the Measurement is ``None``.  Default is
-         ``'UNCERT'``.
-
-    :type hdu_mask: str or None, optional
-    :param hdu_mask: FITS extension from which the mask should be initialized. If the extension does not exist the mask of the Measurement is ``None``.  Default is ``'MASK'``.
-
-    :type hdu_flags: str or None, optional
-    :param hdu_flags: Currently not implemented.  Default is ``None``.
-
-    :type key_uncertainty_type: str, optional
-     :param key_uncertainty_type: The header key name where the class name of the uncertainty  is stored in the hdu of the uncertainty (if any).  Default is ``UTYPE``.
-
-
-    :param kwd: Any additional keyword parameters are passed through to the FITS reader in :mod:`astropy.io.fits`
-
-    :raises TypeError: If the conversion from CCDData to Measurement fails
+    Raises
+    ------
+    TypeError
+        If the conversion from CCDData to Measurement fails.
     """
 
     _id = kwd.pop("identifier", "unknown")

--- a/pdrtpy/measurement.py
+++ b/pdrtpy/measurement.py
@@ -56,23 +56,25 @@ class Measurement(CCDData):
     TypeError
         If beam parameters are not Quantities.
 
-    Measurements can also be instantiated by the **read(\\*args, \\**kwargs)**,
-    to create an Measurement instance based on a ``FITS`` file.
-    This method uses :func:`fits_measurement_reader` with the provided
-    parameters.  Example usage:
+    .. note::
 
-    .. code-block:: python
+        Measurements can also be instantiated by the ``read(*args, **kwargs)`` method,
+        to create an Measurement instance based on a ``FITS`` file.
+        This method uses :func:`fits_measurement_reader` with the provided
+        parameters.  Example usage:
 
-       from pdrtpy.measurement import Measurement
+        .. code-block:: python
 
-       my_obs = Measurement.read("file.fits",identifier="CII_158")
-       my_other_obs = Measurement.read("file2.fits",identifier="CO2_1",
-                                        unit="K km/s",
-                                        bmaj=9.3*u.arcsec,
-                                        bmin=14.1*u.arcsec,
-                                        bpa=23.2*u.degrees)
+           from pdrtpy.measurement import Measurement
 
-    By default image axes with only a single dimension are removed on read.  If you do not want this behavior, used `read(squeeze=False)`. See also: :class:`astropy.nddata.CCDData`.
+           my_obs = Measurement.read("file.fits",identifier="CII_158")
+           my_other_obs = Measurement.read("file2.fits",identifier="CO2_1",
+                                            unit="K km/s",
+                                            bmaj=9.3*u.arcsec,
+                                            bmin=14.1*u.arcsec,
+                                            bpa=23.2*u.degrees)
+
+        By default image axes with only a single dimension are removed on read.  If you do not want this behavior, used `read(squeeze=False)`. See also: :class:`astropy.nddata.CCDData`.
     """
 
     def __init__(self, *args, **kwargs):
@@ -143,6 +145,18 @@ class Measurement(CCDData):
         This format allows the resulting file to be read by the underlying
         :class:`~astropy.nddata.CCDData` class.
 
+        Example:
+
+        .. code:: python
+
+           # example with percentage error
+           Measurement.make_measurement("my_infile.fits",error='10%',outfile="my_outfile.fits")
+
+           # example with measurement in units of K km/s and error
+           # indicated by RMS keyword in input file.
+           Measurement.make_measurement("my_infile.fits", error='rms',
+                                        outfile="my_outfile.fits", unit="K km/s",overwrite=True)
+
         Parameters
         ----------
         datafile : str
@@ -172,16 +186,6 @@ class Measurement(CCDData):
         OSError
             If ``overwrite`` is False and the output file exists.
 
-        Example usage:
-
-        .. code-block:: python
-
-            # example with percentage error
-            Measurement.make_measurement("my_infile.fits",error='10%',outfile="my_outfile.fits")
-
-            # example with measurement in units of K km/s and error
-            # indicated by RMS keyword in input file.
-            Measurement.make_measurement("my_infile.fits",error='rms',outfile="my_outfile.fits",unit="K km/s",overwrite=True)
         """
         _data = fits.open(datafile)
         needsclose = False

--- a/pdrtpy/modelset.py
+++ b/pdrtpy/modelset.py
@@ -15,51 +15,50 @@ from .utils import _OBS_UNIT_, get_table, model_dir
 class ModelSet:
     """Class for computed PDR Model Sets. :class:`ModelSet` provides interface to a directory containing the model FITS files and the ability to query details about.
 
-    :param name: identifying name, e.g., 'wk2006'
-    :type name: str
-
-    :param z:  metallicity in solar units.
-    :type z: float
-
-    :param medium:  medium type, e.g. 'constant density', 'clumpy', 'non-clumpy'
-    :type medium: str
-
-    :param losangle: the line-of-sight inclination angle (aka viewing angle), losangle=0 is face-on, losangle=90 is edge-on.  Valid values are 0, 30, 45, 60, 75, 90.
-    :type  losangle: float
-
-    :param mass: maximum clump mass (for KosmaTau models).  Default:None (appropriate for Wolfire/Kaufman models)
-    :type mass: float
-
-    :param modelsetinfo: For adding user specified ModelSet, this parameter
-        specifies the file with information about the ModelSet. It can be a
-        pathname to an externalt tabular file in an astropy-recognized or an
-        astropy Table object.  If an external tabular file, its format should
-        be give by the `format` keyword. The columns are:
+    Parameters
+    ----------
+    name : str
+        Identifying name, e.g., 'wk2006'.
+    z : float
+        Metallicity in solar units.
+    medium : str
+        Medium type, e.g. 'constant density', 'clumpy', 'non-clumpy'.
+    losangle : float
+        The line-of-sight inclination angle (aka viewing angle), losangle=0 is
+        face-on, losangle=90 is edge-on. Valid values are 0, 30, 45, 60, 75, 90.
+    mass : float
+        Maximum clump mass (for KosmaTau models). Default: None (appropriate for
+        Wolfire/Kaufman models).
+    modelsetinfo : str or :class:`~astropy.table.Table`
+        For adding user specified ModelSet, this parameter specifies the file with
+        information about the ModelSet. It can be a pathname to an external tabular
+        file in an astropy-recognized format or an astropy Table object. If an
+        external tabular file, its format should be given by the `format` keyword.
+        The columns are:
 
         .. code-block:: python
 
            ['PDRcode','name', 'version','path','filename','medium','z','inc', 'mass','description']
 
         `z`, 'inc', and `mass` should be numbers, the rest should be strings.
-        The `name`, `version`, `medium`, `z`, 'inc',  and `mass` columns contain
-        the values available in the input ModelSet as described above. `PDR
-        code` is the originator of the code e.g., "KOSMA-tau", `version`
-        is the code version, `path` is the full-qualified pathname to
-        the FITS files, `filename` is the tabular file which contains
-        descriptions of individual FITS files.  This must also be in
-        the format specified by the `format` keyword.  `description`
-        is a description of the input ModelSet.
-
-    :type modelsetinfo: str or :class:`~astropy.table.Table`
-
-    :param format: If `modelsetinfo` is a file, give the
-        format of file. Must be `an astropy recognized Table format.
+        The `name`, `version`, `medium`, `z`, 'inc', and `mass` columns contain
+        the values available in the input ModelSet as described above. `PDRcode`
+        is the originator of the code e.g., "KOSMA-tau", `version` is the code
+        version, `path` is the full-qualified pathname to the FITS files,
+        `filename` is the tabular file which contains descriptions of individual
+        FITS files. This must also be in the format specified by the `format`
+        keyword. `description` is a description of the input ModelSet.
+    format : str
+        If `modelsetinfo` is a file, give the format of file. Must be
+        `an astropy recognized Table format.
         <https://docs.astropy.org/en/stable/io/unified.html#built-in-readers-writers>`_
         e.g., ascii, ipac, votable. Default is `IPAC format
         <https://docs.astropy.org/en/stable/api/astropy.io.ascii.Ipac.html#astropy.io.ascii.Ipac>`_
-    :type format: str
 
-    :raises ValueError: If model set not recognized/found.
+    Raises
+    ------
+    ValueError
+        If model set not recognized/found.
     """
 
     def __init__(
@@ -144,7 +143,9 @@ class ModelSet:
     def description(self):
         """The description of this model
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         s = f", Z={self.z:2.1f}, losangle={int(self.losangle):d}"
         if self.avlos is not None:
@@ -157,7 +158,9 @@ class ModelSet:
     def code(self):
         """The PDR code that created this ModelSet, e.g. 'KOSMA-tau'
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         return self._tabrow["PDRcode"]
 
@@ -165,7 +168,9 @@ class ModelSet:
     def name(self):
         """The name of this ModelSet
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         return self._tabrow["name"]
 
@@ -173,7 +178,9 @@ class ModelSet:
     def version(self):
         """The version of this ModelSet
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         return self._tabrow["version"]
 
@@ -181,7 +188,9 @@ class ModelSet:
     def medium(self):
         """The medium type of this model, e.g. 'constant density', 'clumpy', 'non-clumpy'
 
-        :rtype: str
+        Returns
+        -------
+        str
         """
         return self._tabrow["medium"]
 
@@ -189,7 +198,9 @@ class ModelSet:
     def z(self):
         """The metallicity of this ModelSet
 
-        :rtype: float
+        Returns
+        -------
+        float
         """
         return self.metallicity
 
@@ -197,21 +208,29 @@ class ModelSet:
     def metallicity(self):
         """The metallicity of this ModelSet
 
-        :rtype: float
+        Returns
+        -------
+        float
         """
         return self._tabrow["z"]
 
     @property
     def losangle(self):
         """The inclination (viewing) angle with respect to the line of sight, in degrees. A value of 0 means face-on.
-        :rtype: float
+
+        Returns
+        -------
+        float
         """
         return self._tabrow["losangle"]
 
     @property
     def viewangle(self):
         """The viewing angle (inclination) with respect to the line of sight, in degrees. A value of 0 means face-on.
-        :rtype: float
+
+        Returns
+        -------
+        float
         """
         return self.losangle
 
@@ -220,7 +239,9 @@ class ModelSet:
         """The PDR thickness for inclined viewing angle models, expressed in visual magnitudes.
         Returns ``None`` for face-on geometry (losangle=0) and for non-wk2020 models.
 
-        :rtype: float or None
+        Returns
+        -------
+        float or None
         """
         if not self.is_wk2020:
             return None
@@ -234,7 +255,9 @@ class ModelSet:
         """The visual extinction along the line of sight, expressed in magnitudes.
         Returns ``None`` for non-wk2020 models.
 
-        :rtype: float or None
+        Returns
+        -------
+        float or None
         """
         if not self.is_wk2020:
             return None
@@ -244,7 +267,9 @@ class ModelSet:
     def table(self):
         """The table containing details of the models in this ModelSet.
 
-        :rtype: :class:`astropy.table.Table`
+        Returns
+        -------
+        :class:`astropy.table.Table`
         """
         return self._table
 
@@ -252,7 +277,9 @@ class ModelSet:
     def identifiers(self):
         """Table of lines and continuum that are included in ratio models of this ModelSet. Only lines and continuum that are part of ratios are included in this list.   For a separate list of line and continuum intensity models see :meth:`~pdrtpy.modelset.ModelSet.supported_intensities`.
 
-        :rtype: :class:`astropy.table.Table`
+        Returns
+        -------
+        :class:`astropy.table.Table`
         """
         return self._identifiers
 
@@ -261,7 +288,9 @@ class ModelSet:
         """Table of lines and continuum that are covered by this ModelSet and have models separate from
         the any ratio model they might be in.
 
-        :rtype: :class:`astropy.table.Table`
+        Returns
+        -------
+        :class:`astropy.table.Table`
         """
         return self._supported_lines
 
@@ -269,7 +298,9 @@ class ModelSet:
     def supported_ratios(self):
         """The emission ratios that are covered by this ModelSet
 
-        :rtype: :class:`astropy.table.Table`
+        Returns
+        -------
+        :class:`astropy.table.Table`
         """
         return self._supported_ratios
 
@@ -277,27 +308,39 @@ class ModelSet:
     def user_added_models(self):
         """Show which models have been added to this ModelSet by the user
 
-        :rtype: list
+        Returns
+        -------
+        list
         """
         return list(self._user_added_models.keys())
 
     def ratiocount(self, m):
         """The number of valid ratios in this ModelSet, given a list of observation (:class:`~pdrtpy.measurement.Measurement`) identifiers.
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :returns: The number of model ratios found for the given list of measurement IDs
-        :rtype: int
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+
+        Returns
+        -------
+        int
+            The number of model ratios found for the given list of measurement IDs.
         """
         return len(self._get_ratio_elements(m))
 
     def find_pairs(self, m):
         """Find the valid model ratios labels in this ModelSet for a given list of measurement IDs
 
-        :param m: list of string `Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :returns: An iterator of model ratios labels for the given list of measurement IDs
-        :rtype: iterator
+        Parameters
+        ----------
+        m : list
+            List of string `Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+
+        Returns
+        -------
+        iterator
+            An iterator of model ratio labels for the given list of measurement IDs.
         """
         if not isinstance(m, collections.abc.Iterable) or isinstance(m, (str, bytes)):
             raise Exception("m must be an array of strings")
@@ -313,12 +356,17 @@ class ModelSet:
     def find_files(self, m, ext="fits"):
         """Find the valid model ratios files in this ModelSet for a given list of measurement IDs.  See :meth:`~pdrtpy.measurement.Measurement.id`
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :param ext: file extension. Default: "fits"
-        :type ext: str
-        :returns: An iterator of model ratio files for the given list of Measurement IDs
-        :rtype: iterator
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+        ext : str
+            File extension. Default: "fits".
+
+        Returns
+        -------
+        iterator
+            An iterator of model ratio files for the given list of Measurement IDs.
         """
         if not isinstance(m, collections.abc.Iterable) or isinstance(m, (str, bytes)):
             raise Exception("m must be an array of strings")
@@ -337,10 +385,15 @@ class ModelSet:
     def model_ratios(self, m):
         """Return the model ratios that match the input Measurement ID list.  You must provide at least 2 Measurements IDs
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","FIR"]
-        :type m: list
-        :returns: list of string identifiers of ratios IDs, e.g., ['OI_145/CII_158', 'OI_145+CII_158/FIR']
-        :rtype: list
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","FIR"].
+
+        Returns
+        -------
+        list
+            List of string identifiers of ratio IDs, e.g., ['OI_145/CII_158', 'OI_145+CII_158/FIR'].
         """
         ratios = list()
         if len(m) < 2:
@@ -353,10 +406,15 @@ class ModelSet:
         """Return the model intensities in this ModelSet that match the input Measurement ID list.
         This method will return the intersection of the input list and the list of supported lines.
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","CS_21"]
-        :type m: list
-        :returns: list of string identifiers of ratios IDs, e.g., ['CII_158','OI_145']
-        :rtype: list
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","CS_21"].
+
+        Returns
+        -------
+        list
+            List of string identifiers of intensity IDs, e.g., ['CII_158','OI_145'].
         """
         # get intersection of input list and supported lines
         return list(set(m) & set(self._supported_lines["intensity label"]))
@@ -364,11 +422,20 @@ class ModelSet:
     def get_model(self, identifier, unit=None, ext="fits"):
         """Get a specific model by its identifier
 
-        :param identifier: a :class:`~pdrtpy.measurement.Measurement` ID. It can be an intensity or a ratio, e.g., "CII_158","CI_609/FIR".
-        :type identifier: str
-        :returns: The model matching the identifier
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
-        :raises KeyError: if identifier not found in this ModelSet
+        Parameters
+        ----------
+        identifier : str
+            A :class:`~pdrtpy.measurement.Measurement` ID. It can be an intensity or a ratio, e.g., "CII_158","CI_609/FIR".
+
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
+            The model matching the identifier.
+
+        Raises
+        ------
+        KeyError
+            If identifier not found in this ModelSet.
         """
 
         if identifier in self._user_added_models:
@@ -436,15 +503,24 @@ class ModelSet:
         return _model
 
     def get_models(self, identifiers, model_type="ratio", ext="fits"):
-        """get the models from thie ModelSet that match the input list of identifiers
+        """Get the models from this ModelSet that match the input list of identifiers
 
-        :param identifiers: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","CS_21"]
-        :type identifiers: list
-        :param model_type: indicates which type of model is requested one of 'ratio' or 'intensity'
-        :type model_type: str
-        :returns: The matching models as a list of :class:`~pdrtpy.measurement.Measurement`.
-        :rtype: list
-        :raises KeyError: if identifiers not found in this ModelSet
+        Parameters
+        ----------
+        identifiers : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g., ["CII_158","OI_145","CS_21"].
+        model_type : str
+            Indicates which type of model is requested: one of 'ratio' or 'intensity'.
+
+        Returns
+        -------
+        list
+            The matching models as a list of :class:`~pdrtpy.measurement.Measurement`.
+
+        Raises
+        ------
+        KeyError
+            If identifiers not found in this ModelSet.
         """
 
         # if identifier not in self._identifiers["ID"]:
@@ -476,14 +552,19 @@ class ModelSet:
     def add_model(self, identifier, model, title, overwrite=False):
         r"""Add your own model to this ModelSet.
 
-        :param identifier: a :class:`~pdrtpy.measurement.Measurement` ID. It can be an intensity or a ratio, e.g., "CII_158","CI_609/FIR".
-        :type identifier: str
-        :param model:  the model to add.  If a string, this must be the fully-qualified path of a FITS file.  If a :class:`~pdrtpy.measurement.Measurement` it must have the same CTYPEs and CUNITs as the models in the ModelSet(?).
-        :type model: str or :class:`~pdrtpy.measurement.Measurement`
-        :param title: A formatted string (e.g., LaTeX) describing this observation that can be used for plotting. Python r-strings are accepted, e.g., r'$^{13}$CO(3-2)'  would give :math:`^{13}{\rm CO(3-2)}`.
-        :type title: str
-            :param overwrite:  Whether to overwrite the model if the identifier already exists in the ModelSet or has been previously added.  Default: False
-            :type overwrite: bool
+        Parameters
+        ----------
+        identifier : str
+            A :class:`~pdrtpy.measurement.Measurement` ID. It can be an intensity or a ratio, e.g., "CII_158","CI_609/FIR".
+        model : str or :class:`~pdrtpy.measurement.Measurement`
+            The model to add. If a string, this must be the fully-qualified path of a FITS file.
+            If a :class:`~pdrtpy.measurement.Measurement` it must have the same CTYPEs and CUNITs as the models in the ModelSet.
+        title : str
+            A formatted string (e.g., LaTeX) describing this observation that can be used for plotting.
+            Python r-strings are accepted, e.g., r'$^{13}$CO(3-2)' would give :math:`^{13}{\rm CO(3-2)}`.
+        overwrite : bool
+            Whether to overwrite the model if the identifier already exists in the ModelSet or has been
+            previously added. Default: False.
         """
         if identifier not in self.table["ratio"] and identifier not in self._user_added_models:
             self._really_add_model(identifier, model, title)
@@ -530,9 +611,15 @@ class ModelSet:
         # TODO handle case of OI+CII/FIR so it is not special cased in lineratiofit.py
         """Find the valid model numerator,denominator pairs in this ModelSet for a given list of measurement IDs. See :meth:`~pdrtpy.measurement.Measurement.id`
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :returns: iterator -- An dictionary iterator where key is numerator and value is denominator
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+
+        Returns
+        -------
+        iterator
+            A dictionary iterator where key is numerator and value is denominator.
         """
         if not isinstance(m, collections.abc.Iterable) or isinstance(m, (str, bytes)):
             raise Exception("m must be an array of strings")
@@ -547,9 +634,15 @@ class ModelSet:
     def _get_ratio_elements(self, m):
         """Get the valid model numerator,denominator pairs in this ModelSet for a given list of measurement IDs. See :meth:`~pdrtpy.measurement.Measurement.id`
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :returns: dict -- A dictionary where key is numerator and value is denominator
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+
+        Returns
+        -------
+        dict
+            A dictionary where key is numerator and value is denominator.
         """
         if not isinstance(m, collections.abc.Iterable) or isinstance(m, (str, bytes)):
             raise Exception("m must be an array of strings")
@@ -566,10 +659,12 @@ class ModelSet:
         """Utility method for determining ratio elements, to handle special
            case of ([O I] 63 micron + [C II] 158 micron)/I_FIR.
 
-        :param m: list of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"]
-        :type m: list
-        :param k: list of existing ratios to append to
-        :type k: list
+        Parameters
+        ----------
+        m : list
+            List of string :class:`~pdrtpy.measurement.Measurement` IDs, e.g. ["CII_158","OI_145","FIR"].
+        k : list
+            List of existing ratios to append to.
         """
         if "CII_158" in m and "FIR" in m:
             if "OI_63" in m:
@@ -632,19 +727,23 @@ class ModelSet:
 
     @property
     def is_wk2006(self):
-        """method to indicate this is a wk2006 model, to deal with quirks
-        of that modelset
+        """Indicate this is a wk2006 model, to deal with quirks of that modelset.
 
-        :returns: True if it is.
+        Returns
+        -------
+        bool
+            True if it is.
         """
         return self.name == "wk2006"
 
     @property
     def is_wk2020(self):
-        """method to indicate this is a wk2020 model, to deal with quirks
-        of that modelset
+        """Indicate this is a wk2020 model, to deal with quirks of that modelset.
 
-        :returns: True if it is.
+        Returns
+        -------
+        bool
+            True if it is.
         """
         return self.name == "wk2020"
 
@@ -658,7 +757,9 @@ class ModelSet:
     def all_sets(debug=False):
         """Return a table of the names and descriptions of available ModelSets (not just this one)
 
-        :rtype: :class:`~astropy.table.Table`
+        Returns
+        -------
+        :class:`~astropy.table.Table`
         """
         t = get_table("all_models.tab")
         t.remove_column("path")

--- a/pdrtpy/molecule.py
+++ b/pdrtpy/molecule.py
@@ -51,7 +51,7 @@ class BaseMolecule:
 
         Parameters
         ----------
-        temperature :  :class:`astropy.units.quantity.Quantity`
+        temperature :  :class:`~astropy.units.Quantity`
             The excitation temperature(s)
 
         Returns
@@ -70,7 +70,7 @@ class BaseMolecule:
 
         Parameters
         ----------
-        temperature : :class:`astropy.units.quantity.Quantity`
+        temperature : :class:`~astropy.units.Quantity`
             The excitation temperature(s)
 
         Returns
@@ -158,7 +158,7 @@ class BaseMolecule:
 
         Returns
         -------
-        `~astropy.units.quantity.Quantity`
+        `~astropy.units.Quantity`
 
             The spectral line wavelengths
 
@@ -168,7 +168,7 @@ class BaseMolecule:
 
 class H2(BaseMolecule):
     def __init__(self, name="H_2", path="RoueffEtAl.tab", opr=3.0, opr_can_vary=True):
-        """Molecular hydrogen. This uses the `H_2` line calculations from Roueff et al 2019, A&A, 630, 58, Table 2."""
+        """Molecular hydrogen. This uses the :math:`H_2` line calculations from Roueff et al 2019, A&A, 630, 58, Table 2."""
         super().__init__(name=name, path=path, opr=opr, opr_can_vary=True, format="ascii.ipac")
 
     def partition_function(self, temperature: Quantity) -> np.ndarray:
@@ -182,7 +182,7 @@ class H2(BaseMolecule):
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature :  :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns
@@ -218,7 +218,7 @@ class CO(BaseMolecule):  # 12C16O
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature :  :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns
@@ -243,7 +243,7 @@ class C13O(BaseMolecule):  # 13CO16O
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature :  :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns
@@ -262,13 +262,13 @@ class CO18(BaseMolecule):  # 12CO18O
         self._maxQtemp = np.max(self._partfun_data["T"])
 
     def partition_function(self, temperature: Quantity) -> np.ndarray:
-        """Calculate the partition function for C18O at the given temperature using the HITRAN partition function.
+        """Calculate the partition function for :math:`^{12}C^{18}O` at the given temperature using the HITRAN partition function.
         https://hitran.org/data/Q/q28.txt
         The HITRAN function is evaluated at 1K intervals; this function performs a linear interpolation on those data.
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature : :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns
@@ -293,7 +293,7 @@ class C13O18(BaseMolecule):  # 13C18O
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature : :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns
@@ -306,25 +306,27 @@ class C13O18(BaseMolecule):  # 13C18O
 
 class CHplus(BaseMolecule):  # CH+
     def __init__(self, name="CH^+", path="CH_p_transition.tab", opr=3.0, opr_can_vary=True):
-        r"""Methyl Cation isotopologue :math:`^{12}C^H^{+}:`. This uses the molecular data from both the Meudon PDR7 code and EXOMOL database"""
+        r"""Methyl Cation isotopologue :math:`^{12}CH^{+}`. This uses the molecular data from both the Meudon PDR7 code and EXOMOL database"""
         super().__init__(name, path, opr, opr_can_vary)
         self._partfun_data = utils.get_table("PartFun_CH_p.tab", format="ascii.ecsv")
         self._maxQtemp = np.max(self._partfun_data["T"])
 
     def partition_function(self, temperature: Quantity) -> np.ndarray:
         r"""
-        Calculate the partition function for $CH^{+}$ at the given temperature using the EXOMOL partition function `(Pearce et al., 2024, MNRAS, 527, 10736)  <https://doi.org/10.1093/mnras/stad3909>`_.
+        Calculate the partition function for :math:`^{12}CH^{+}` at the given temperature using the EXOMOL partition function `(Pearce et al., 2024, MNRAS, 527, 10736)  <https://doi.org/10.1093/mnras/stad3909>`_.
         The EXOMOL function is evaluated at 1K intervals; this function performs a linear interpolation on those data.
 
-        ..note:
+        .. note::
 
-            Per Pearce+2024, "The ExoMol convention, in accordance with HITRAN `(Gamache et al. 2017, J. Quant. Spectrosc. Radiat. Transfer, 203, 70) <https://doi.org/10.1016/j.jqsrt.2017.03.045>`_ , is
-            to provide partition functions that include full atomic nuclear spin degeneracy, $g_{nu}$."  This results in a factor of 2 increase over the
-            partition functions of `Barklem and Collet (2016, A&A,588,A96) <https://doi.org/10.1051/0004-6361/201526961>`_ and of `Godard and Cernicharo (2013) A&A, 550, A8. <https://doi.org/10.1051/0004-6361/201220151>`_ Be aware of this when comparing total column densities with papers that use those partition functions.
+           As described in Pearce+2024, "The ExoMol convention, in accordance with HITRAN `(Gamache et al. 2017, J. Quant. Spectrosc. Radiat. Transfer, 203, 70) <https://doi.org/10.1016/j.jqsrt.2017.03.045>`_ , is
+           to provide partition functions that include full atomic nuclear spin degeneracy, :math:`g_{nu}`."
+
+           This results in a factor of 2 increase over the
+           partition functions of `Barklem and Collet (2016, A&A,588,A96) <https://doi.org/10.1051/0004-6361/201526961>`_ and of `Godard and Cernicharo (2013) A&A, 550, A8. <https://doi.org/10.1051/0004-6361/201220151>`_ Be aware of this when comparing total column densities with papers that use those partition functions.
 
         Parameters
         ----------
-        temperature  :class:`astropy.units.quantity.Quantity`
+        temperature : :class:`~astropy.units.Quantity`
             The excitation temperature(s) at which to evaluate the partition function
 
         Returns

--- a/pdrtpy/plot/excitationplot.py
+++ b/pdrtpy/plot/excitationplot.py
@@ -54,17 +54,28 @@ class ExcitationPlot(PlotBase):
         # @todo position and size might not necessarily match how the fit was done.
         #:type position: tuple or :class:`astropy.coordinates.SkyCoord`
         # or a :class:`~astropy.coordinates.SkyCoord`, which will use the :class:`~astropy.wcs.WCS` of the ::class:`~pdrtpy.measurement.Measurement`s added to this tool.
-        r"""Plot the excitation diagram.  For maps of excitation parameters, a position and optional size are required.  To examine the entire map, use :meth:`explore`.
+        r"""Plot the excitation diagram.
 
-        :param position: The spatial position of excitation diagram.  For spatial averaging this is the cutout array's center with respect to the data array. The position may be specified as an `(x, y)` tuple of pixel coordinates or a SkyCoord coordinate
-        :type position: tuple or :class:`~astropy.coordinates.SkyCoord`
-        :param size: The size of the cutout array along each axis. If size is a scalar number or a scalar :class:`~astropy.units.Quantity`, then a square cutout of size will be created. If `size` has two elements, they should be in `(ny, nx)` order. Scalar numbers in size are assumed to be in units of pixels. `size` can also be a :class:`~astropy.units.Quantity` object or contain :class:`~astropy.units.Quantity` objects. Such :class:`~astropy.units.Quantity` objects must be in pixel or angular units. For all cases, size will be converted to an integer number of pixels, rounding the the nearest integer.  See :class:`~astropy.nddata.utils.Cutout2D`
-        :type size: int, array_like, or :class:`astropy.units.Quantity`
-        :param norm: if True, normalize the column densities by the
-                       statistical weight of the upper state, :math:`g_u`.
-        :type norm: bool
-        :param show_fit: Show the most recent fit done the the associated H2ExcitationFit tool.
-        :type show_fit: bool
+        For maps of excitation parameters, a position and optional size are required.
+        To examine the entire map, use :meth:`explore`.
+
+        Parameters
+        ----------
+        position : tuple or :class:`~astropy.coordinates.SkyCoord`, optional
+            The spatial position of the excitation diagram. For spatial averaging
+            this is the cutout array's center. May be an ``(x, y)`` tuple of pixel
+            coordinates or a :class:`~astropy.coordinates.SkyCoord`.
+        size : int, array_like, or :class:`~astropy.units.Quantity`, optional
+            The size of the cutout array along each axis. If scalar, a square
+            cutout is created. If two elements, they should be in ``(ny, nx)``
+            order. Scalar numbers are assumed to be in pixels. Quantity objects
+            must be in pixel or angular units. See :class:`~astropy.nddata.utils.Cutout2D`.
+        norm : bool, optional
+            If True, normalize the column densities by the statistical weight of
+            the upper state :math:`g_u`. Default: True.
+        show_fit : bool, optional
+            Show the most recent fit from the associated excitation fit tool.
+            Default: False.
         """
         # suppress ridiculous NDDATA warning about units. See issue #163
         log.setLevel("WARNING")
@@ -353,8 +364,10 @@ class ExcitationPlot(PlotBase):
     def temperature(self, component, **kwargs):
         """Plot the temperature of hot or cold gas component.
 
-        :param component: 'hot' or 'cold'
-        :type component: str
+        Parameters
+        ----------
+        component : str
+            ``'hot'`` or ``'cold'``.
         """
         if component not in self._tool.temperature:
             raise KeyError(f"{component} not a valid component. Must be one of {list(self._tool.temperature.keys())}")
@@ -363,9 +376,12 @@ class ExcitationPlot(PlotBase):
     def column_density(self, component, log=True, **kwargs):
         """Plot the column density of hot or cold gas component, or total column density.
 
-        :param component: 'hot', 'cold', or 'total
-        :type component: str
-        :param log: take the log10 of the column density before plotting
+        Parameters
+        ----------
+        component : str
+            ``'hot'``, ``'cold'``, or ``'total'``.
+        log : bool, optional
+            Take the log10 of the column density before plotting. Default: True.
         """
         self._plot(self._tool.colden(component), log=log, **kwargs)
 
@@ -376,19 +392,29 @@ class ExcitationPlot(PlotBase):
         self._plot(self._tool.opr, **kwargs)
 
     def explore(self, data=None, interaction_type="click", **kwargs):
-        r"""Explore the fitted parameters of a map. A user-requested map is displayed in the left panel and in the right panel is the fitted excitation diagram for a point selected by the user.  The user clicks on a point in the left panel and the right panel will update with the excitation diagram for that point.
+        r"""Explore the fitted parameters of a map interactively.
 
-        :param data: A reference image to use for the left panel, e.g. the total column density, the cold temperature, etc.  This should be a reference results in the :class:`~pdrtpy.tool.h2excitation.H2Excitation` tool used for this :class:`~pdrtpy.plot.excitationplot.ExcitationPlot` (e.g., *htool.temperature['cold']*)
-        :type data: :class:`~pdrtpy.measurement.Measurement`
-        :param interaction_type: whether to use mouse click or mouse move to update the right hand panel.   Valid values are 'click' or 'move'.
-        :type interaction_type: str
-        :param \*\*kwargs: Other parameters passed to :meth:`~pdrtpy.plot.excitationplot.ExcitationPlot._plot`, :meth:`~pdrtpy.plot.excitationplot.ExcitationPlot.ex_diagram`, or matplotlib methods.
+        A user-requested map is displayed in the left panel; the right panel shows
+        the fitted excitation diagram for a user-selected point.
 
-            - *units,image, contours, label, title, norm, figsize* -- See the general `Plot Keywords`_ documentation
-            - *show_fit* - show the fit in the excitation diagram, Default: True
-            - *log* - plot the log10 of the image, can be useful for column density,  Default: False
-            - *markersize* - size of the marker displayed where clicked, in points, Default: 20
-            - *fmt* - matplotlib format for the marker, Default:. 'r+'
+        Parameters
+        ----------
+        data : :class:`~pdrtpy.measurement.Measurement`, optional
+            Reference image for the left panel, e.g. total column density or
+            cold temperature from the associated excitation tool
+            (e.g. ``htool.temperature['cold']``).
+        interaction_type : str, optional
+            Whether to update the right panel on mouse ``'click'`` or
+            ``'move'``. Default: ``'click'``.
+        \*\*kwargs
+            Other parameters passed to :meth:`~pdrtpy.plot.excitationplot.ExcitationPlot._plot`,
+            :meth:`~pdrtpy.plot.excitationplot.ExcitationPlot.ex_diagram`, or matplotlib methods.
+
+            - *units, image, contours, label, title, norm, figsize* — see the general `Plot Keywords`_ documentation
+            - *show_fit* — show the fit in the excitation diagram. Default: True
+            - *log* — plot the log10 of the image. Default: False
+            - *markersize* — size of the marker displayed where clicked, in points. Default: 20
+            - *fmt* — matplotlib format for the marker. Default: ``'r+'``
         """
 
         kwargs_opts = {

--- a/pdrtpy/plot/lineratioplot.py
+++ b/pdrtpy/plot/lineratioplot.py
@@ -13,20 +13,21 @@ log.setLevel("WARNING")  # see issue 163
 
 
 class LineRatioPlot(PlotBase):
-    """LineRatioPlot plots the results of :class:`~pdrtpy.tools.lineratiofit.LineRatioFit`.  It can plot maps of fit results, observations with errors on top of models, chi-square and confidence intervals and more.
+    """Plots the results of :class:`~pdrtpy.tools.lineratiofit.LineRatioFit`.
 
+    Can plot maps of fit results, observations with errors on top of models,
+    chi-square and confidence intervals and more.
 
-    :Keyword Arguments:
-
-    The methods of this class can take a variety of optional keywords.  See the general `Plot Keywords`_ documentation
-
+    The methods of this class can take a variety of optional keywords. See the
+    general `Plot Keywords`_ documentation.
     """
 
     def __init__(self, tool):
-        """Init method
-
-        :param tool: The line ratio fitting tool that is to be plotted.
-        :type tool: `~pdrtpy.tool.LineRatioFit`
+        """
+        Parameters
+        ----------
+        tool : :class:`~pdrtpy.tool.LineRatioFit`
+            The line ratio fitting tool that is to be plotted.
         """
 
         super().__init__(tool)
@@ -36,12 +37,19 @@ class LineRatioPlot(PlotBase):
         self._ratiocolor = []
 
     def modelintensity(self, id, **kwargs):
-        r"""Plot one of the model intensities
+        r"""Plot one of the model intensities.
 
-        :param id: the intensity identifier, such as `CO_32``.
-        :type id: str
-        :param \**kwargs: see class documentation above
-        :raises KeyError: if is id not in existing model intensities
+        Parameters
+        ----------
+        id : str
+            The intensity identifier, such as ``CO_32``.
+        \**kwargs
+            See class documentation above.
+
+        Raises
+        ------
+        KeyError
+            If id is not in existing model intensities.
         """
         ms = self._tool.modelset
         if id not in ms.supported_intensities["intensity label"]:
@@ -55,13 +63,19 @@ class LineRatioPlot(PlotBase):
         self._axis = self._modelplot.axis
 
     def modelratio(self, id, **kwargs):
-        r"""Plot one of the model ratios
+        r"""Plot one of the model ratios.
 
-        :param id: the ratio identifier, such as ``CII_158/CO_32``.
-        :type id: str
-        :param \**kwargs: see class documentation above
-        :raises KeyError: if is id not in existing model ratios
+        Parameters
+        ----------
+        id : str
+            The ratio identifier, such as ``CII_158/CO_32``.
+        \**kwargs
+            See class documentation above.
 
+        Raises
+        ------
+        KeyError
+            If id is not in existing model ratios.
         """
         if self._tool._modelratios[id].shape == (1,):  # does this ever occur??
             return self._tool._modelratios[id]
@@ -77,11 +91,17 @@ class LineRatioPlot(PlotBase):
         self._axis = self._modelplot.axis
 
     def observedratio(self, id, **kwargs):
-        """Plot one of the observed ratios
+        """Plot one of the observed ratios.
 
-        :param id: the ratio identifier, such as ``CII_158/CO_32``.
-        :type id: - str
-        :raises KeyError: if id is not in existing observed ratios
+        Parameters
+        ----------
+        id : str
+            The ratio identifier, such as ``CII_158/CO_32``.
+
+        Raises
+        ------
+        KeyError
+            If id is not in existing observed ratios.
         """
         if self._tool._observedratios[id].shape == (1, 0) or self._tool.has_vectors:
             return self._tool._observedratios[id]
@@ -149,11 +169,18 @@ class LineRatioPlot(PlotBase):
     def _plot_chisq_impl(self, data_fn, title, min_val, label_sym, kwargs):
         """Shared implementation for chisq() and reduced_chisq().
 
-        :param data_fn: bound tool method returning the chi-square data (tool.chisq or tool.reduced_chisq)
-        :param title: axis/legend title string (e.g. r'$\\chi^2$ (dof=3)')
-        :param min_val: scalar minimum chi-square value to show in the legend label
-        :param label_sym: LaTeX symbol for the minimum, e.g. r'$\\chi_{min}^2$'
-        :param kwargs: caller's **kwargs dict
+        Parameters
+        ----------
+        data_fn : callable
+            Bound tool method returning the chi-square data (``tool.chisq`` or ``tool.reduced_chisq``).
+        title : str
+            Axis/legend title string, e.g. ``r'$\\chi^2$ (dof=3)'``.
+        min_val : float
+            Scalar minimum chi-square value to show in the legend label.
+        label_sym : str
+            LaTeX symbol for the minimum, e.g. ``r'$\\chi_{min}^2$'``.
+        kwargs : dict
+            Caller's ``**kwargs`` dict.
         """
         kwargs_opts = {
             "units": None,

--- a/pdrtpy/plot/modelplot.py
+++ b/pdrtpy/plot/modelplot.py
@@ -49,7 +49,9 @@ class ModelPlot(PlotBase):
         identifier : str
             Identifier tag for the model to plot, e.g., ``"CII_158"``, ``"OI_145"``, ``"CO_43/CO_21"``.
 
-        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_lines` for a list of available identifier tags.
+        See Also
+        --------
+        :meth:`~pdrtpy.modelset.ModelSet.supported_lines` : for a list of available identifier tags.
         """
         kwargs_opts = {"measurements": None}
         kwargs_opts.update(kwargs)
@@ -66,7 +68,9 @@ class ModelPlot(PlotBase):
         identifier : str
             Identifier tag for the model to plot, e.g., ``"OI_63+CII_158/FIR"``, ``"CO_43/CO_21"``.
 
-        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_ratios` for a list of available identifier tags.
+        See Also
+        --------
+        :meth:`~pdrtpy.modelset.ModelSet.supported_ratios` : for a list of available identifier tags.
         """
         ms = self._modelset
         model = ms.get_model(identifier)
@@ -119,7 +123,9 @@ class ModelPlot(PlotBase):
         identifier : str
             Identifier tag for the model to plot, e.g., ``"OI_63"``, ``"CII_158"``, ``"CO_10"``.
 
-        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_intensities` for a list of available identifier tags.
+        See Also
+        --------
+        :meth:`~pdrtpy.modelset.ModelSet.supported_intensities` : for a list of available identifier tags.
         """
         ms = self._modelset
         meas = kwargs.get("measurements", None)

--- a/pdrtpy/plot/modelplot.py
+++ b/pdrtpy/plot/modelplot.py
@@ -17,18 +17,24 @@ log.setLevel("WARNING")  # see issue 163
 
 
 class ModelPlot(PlotBase):
-    """ModelPlot is a tool for exploring sets of models.  It can plot individual intensity or ratio models, phase-space diagrams, and optionally overlay observations.   Units are seamlessly transformed, so you can plot in Habing units, Draine units, or any conformable quantity.  ModelPlot does not require model fitting with :class:`~pdrtpy.tool.lineratiofit.LineRatioFit` first.
+    """Tool for exploring sets of models.
 
-    :Keyword Arguments:
+    Can plot individual intensity or ratio models, phase-space diagrams, and
+    optionally overlay observations. Units are seamlessly transformed, so you
+    can plot in Habing units, Draine units, or any conformable quantity.
+    ModelPlot does not require model fitting with
+    :class:`~pdrtpy.tool.lineratiofit.LineRatioFit` first.
 
-    The methods of this class can take a variety of optional keywords.  See the general `Plot Keywords`_ documentation.
+    The methods of this class can take a variety of optional keywords. See the
+    general `Plot Keywords`_ documentation.
     """
 
     def __init__(self, modelset, figure=None, axis=None):
-        """Init method
-
-        :param modelset: The set of models to use in these plots.
-        :type modelset: `~pdrtpy.modelset.ModelSet`
+        """
+        Parameters
+        ----------
+        modelset : :class:`~pdrtpy.modelset.ModelSet`
+            The set of models to use in these plots.
         """
         super().__init__(tool=None)
         self._modelset = modelset
@@ -36,12 +42,14 @@ class ModelPlot(PlotBase):
         self._axis = axis
 
     def plot(self, identifier, **kwargs):
-        """Plot a model intensity or ratio
+        """Plot a model intensity or ratio.
 
-        :param identifier: Identifier tag for the model to plot, e.g., "CII_158","OI_145","CO_43/CO_21']
-        :type identifier: str
+        Parameters
+        ----------
+        identifier : str
+            Identifier tag for the model to plot, e.g., ``"CII_158"``, ``"OI_145"``, ``"CO_43/CO_21"``.
 
-        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_lines` for a list of available identifer tags
+        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_lines` for a list of available identifier tags.
         """
         kwargs_opts = {"measurements": None}
         kwargs_opts.update(kwargs)
@@ -51,12 +59,14 @@ class ModelPlot(PlotBase):
             self.intensity(identifier, **kwargs_opts)
 
     def ratio(self, identifier, **kwargs):
-        """Plot a model ratio
+        """Plot a model ratio.
 
-        :param identifier: Identifier tag for the model to plot, e.g., "OI_63+CII_158/FIR", "CO_43/CO_21']
-        :type identifier: str
+        Parameters
+        ----------
+        identifier : str
+            Identifier tag for the model to plot, e.g., ``"OI_63+CII_158/FIR"``, ``"CO_43/CO_21"``.
 
-        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_ratios` for a list of available identifer tags
+        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_ratios` for a list of available identifier tags.
         """
         ms = self._modelset
         model = ms.get_model(identifier)
@@ -102,12 +112,14 @@ class ModelPlot(PlotBase):
             )
 
     def intensity(self, identifier, **kwargs):
-        """Plot a model intensity
+        """Plot a model intensity.
 
-        :param identifier: Identifier tag for the model to plot, e.g., "OI_63", "CII_158", "CO_10"]
-        :type identifier: str
+        Parameters
+        ----------
+        identifier : str
+            Identifier tag for the model to plot, e.g., ``"OI_63"``, ``"CII_158"``, ``"CO_10"``.
 
-        .. seealso::  :meth:`~pdrtpy.modelset.ModelSet.supported_intensities` for a list of available identifer tags
+        .. seealso:: :meth:`~pdrtpy.modelset.ModelSet.supported_intensities` for a list of available identifier tags.
         """
         ms = self._modelset
         meas = kwargs.get("measurements", None)
@@ -162,13 +174,19 @@ class ModelPlot(PlotBase):
             )
 
     def overlay(self, measurements, **kwargs):
-        """Overlay one or more single-pixel measurements in the model space :math:`(n,F_{FUV})`.
+        r"""Overlay one or more single-pixel measurements in the model space :math:`(n,F_{FUV})`.
 
-        :param measurements: a list of one or more :class:`~pdrtpy.measurement.Measurement` to overlay.
-        :type measurements: list
-        :param shading: Controls how measurements and errors are drawn.  If ``shading`` is zero, Measurements will be drawn in solid contour for the value and dashed for the +/- errors. If ``shading`` is between 0 and 1, Measurements are drawn with as filled contours representing the size of the errors (see :func:`matplotlib.pyplot.contourf`) with alpha set to the ``shading`` value.  Default value: 0.4
-        :type shading: float
-
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            A list of one or more Measurements to overlay.
+        shading : float, optional
+            Controls how measurements and errors are drawn. If 0, Measurements
+            will be drawn as solid contours for the value and dashed for the
+            +/- errors. If between 0 and 1, Measurements are drawn as filled
+            contours representing the size of the errors (see
+            :func:`matplotlib.pyplot.contourf`) with alpha set to the
+            ``shading`` value. Default: 0.4.
         """
 
         kwargs_opts = {
@@ -237,16 +255,21 @@ class ModelPlot(PlotBase):
             )
 
     def isoplot(self, identifier, plotnaxis, nax_clip=None, **kwargs):
-        """Plot lines of constant model parameter as a function of the other model parameter and a model intensity or ratio
+        """Plot lines of constant model parameter as a function of the other model parameter and a model intensity or ratio.
 
-        :param identifier: identifier tag for the model to plot, e.g., "OI_63/CO_21" or "CII_158"
-        :type identifier:  str
-        :param plotnaxis: Which NAXIS to use to compute lines of constant value. Since models have two axes, this must be either 1 or 2
-        :type plotnaxis: int
-        :param nax_clip: The range of model parameters on NAXIS{plotnaxis} to show in the plot.  Must be given as a range of astropy quanitities, e.g. [10,1E7]*Unit("cm-3"). Default is None which means plot full range of the parameter.
-        :type nax_clip: array-like, must contain :class:`~astropy.units.Quantity`
-        :param step: Allows skipping of lines of constant value, e.g. plot every `step-th` value. Useful when parameter space is crowded, and a cleaner looking plot is desired.  Default: 1 -- plot every value
-        :type step: int
+        Parameters
+        ----------
+        identifier : str
+            Identifier tag for the model to plot, e.g., ``"OI_63/CO_21"`` or ``"CII_158"``.
+        plotnaxis : int
+            Which NAXIS to use to compute lines of constant value. Since models
+            have two axes, this must be either 1 or 2.
+        nax_clip : array-like of :class:`~astropy.units.Quantity`, optional
+            The range of model parameters on NAXIS{plotnaxis} to show.
+            e.g. ``[10, 1E7]*Unit("cm-3")``. Default: None (full range).
+        step : int, optional
+            Allows skipping lines of constant value, e.g. plot every ``step``-th
+            value. Useful when parameter space is crowded. Default: 1.
         """
         kwargs_opts = {
             "errorbar": False,
@@ -366,54 +389,52 @@ class ModelPlot(PlotBase):
         reciprocal=None,
         **kwargs,
     ):
-        r"""Plot lines of constant density and radiation field on a ratio-ratio, ratio-intensity, or intensity-intensity map
+        r"""Plot lines of constant density and radiation field on a ratio-ratio, ratio-intensity, or intensity-intensity map.
 
-        :param identifiers: list of two identifier tags for the model to plot, e.g., ["OI_63/CO_21", "CII_158"]
-        :type identifiers: list of str
-
-        :param nax1_clip: The range of model densities on NAXIS1 to show
-            in the plot. For most models, NAXIS1 is hydrogen number density
-            :math:`n_H` in :math:`{\rm cm}^{-3}`.  For ionized gas models, it is
-            electron temperature :math:`T_e` in K.  Must be given as a range
-            of astropy quanitities.  Default: [10,1E7]*Unit("cm-3") (if `nax1_clip` set to None).
-        :type nax1_clip: array-like, must contain :class:`~astropy.units.Quantity`
-        :param nax2_clip: The range of model parameters on NAXIS2 to
-            show in the plot.  For most models, NAXIS2 is radiation field
-            intensities in Habing or cgs units.  For ionized gas models, it is
-            electron volume density :math:`n_e`.  Must be given as a range of
-            astropy quantities.  Default: nax1_clip=[10,1E6]*utils.habing_unit (if `nax2_clip` set to None).
-        :type nax2_clip: array-like, must contain :class:`~astropy.units.Quantity`
-        :param reciprocal: Whether or not the plot the reciprocal of the
-            model on each axis.  Given as a pair of booleans.  e.g. [False,True]
-            means don't flip the quantity X axis, but flip quantity the Y axis.
-            i.e. if the model is "CII/OI", and reciprocal=True then the axis
-            will be "OI/CII".  Default: [False, False]
-        :type reciprocal: array-like bool
-
-        The following keywords are supported as \*\*kwargs:
-
-        :param measurements: A list of two :class:`~pdrtpy.measurement.Measurement`, one for each `identifier`, that will be used to plot a data point on the grid. At least two Measurements, one for x and one for y, must be given.  Subsequent Measurements must also be paired since they represent x and y, e.g `[m1x, m1y, m2x, m2y,...]`. Measurement *data* and *uncertainty* members may be arrays.  Default: None
-        :type measurements: array-like of :class:`~pdrtpy.measurment.Measurement`.
-        :param errorbar: Plot error bars when given measurements. Default: True
-        :type errorbar: bool
-        :param fmt: The format to use when plotting Measurement data. There should be one for each pair of Measurements. See :meth:`matplotlib.axes.Axes.plot` for examples. Default is 'sk' for all points.
-        :type fmt: array of str
-        :param label: The label(s) to use the Measurement data legend. There should be one for each pair of Measurements.  Default is 'data' for all points.
-        :type label: array of str
-        :param legend: Draw a legend on the plot. Default: True
-        :type legend: bool
-        :param title: Title to draw on the plot.  Default: None
-        :type title: str
-        :param linewidth: line width
-        :type linewidth: float
-        :param grid: show grid or not, Default: True
-        :type grid: bool
-        :param figsize: Figure dimensions (width, height) in inches. Default: (8,5)
-        :type figsize: 2-tuple of floats
-        :param capsize: end cap length of errorbars if shown, in points. Default: 3.
-        :type capsize: float
-        :param markersize: size of data point marker in points. Default: 8
-        :type markersize: float
+        Parameters
+        ----------
+        identifiers : list of str
+            List of two identifier tags for the model to plot, e.g.,
+            ``["OI_63/CO_21", "CII_158"]``.
+        nax1_clip : array-like of :class:`~astropy.units.Quantity`, optional
+            Range of model densities on NAXIS1 to show. For most models, NAXIS1
+            is hydrogen number density :math:`n_H` in :math:`{\rm cm}^{-3}`.
+            For ionized gas models, it is electron temperature :math:`T_e` in K.
+            Default: ``[10, 1E7]*Unit("cm-3")``.
+        nax2_clip : array-like of :class:`~astropy.units.Quantity`, optional
+            Range of model parameters on NAXIS2. For most models, NAXIS2 is
+            radiation field intensities in Habing or cgs units. For ionized gas
+            models, it is electron volume density :math:`n_e`.
+            Default: ``[10, 1E6]*utils.habing_unit``.
+        reciprocal : array-like of bool, optional
+            Whether to plot the reciprocal of the model on each axis. e.g.
+            ``[False, True]`` means don't flip the X axis but flip the Y axis.
+            Default: ``[False, False]``.
+        measurements : array-like of :class:`~pdrtpy.measurement.Measurement`, optional
+            A list of two Measurements, one per identifier, to plot as data
+            points on the grid. Pairs must be given as ``[m1x, m1y, m2x, m2y, ...]``.
+            Default: None.
+        errorbar : bool, optional
+            Plot error bars when given measurements. Default: True.
+        fmt : array of str, optional
+            Plot format for each Measurement pair. See :meth:`matplotlib.axes.Axes.plot`.
+            Default: ``'sk'`` for all points.
+        label : array of str, optional
+            Legend label(s) for each Measurement pair. Default: ``'data'`` for all.
+        legend : bool, optional
+            Draw a legend on the plot. Default: True.
+        title : str, optional
+            Title to draw on the plot. Default: None.
+        linewidth : float, optional
+            Line width.
+        grid : bool, optional
+            Show grid. Default: True.
+        figsize : 2-tuple of float, optional
+            Figure dimensions (width, height) in inches. Default: ``(8, 5)``.
+        capsize : float, optional
+            End cap length of errorbars in points. Default: 3.
+        markersize : float, optional
+            Size of data point marker in points. Default: 8.
         """
         kwargs_opts = {
             "errorbar": False,
@@ -661,14 +682,19 @@ class ModelPlot(PlotBase):
     def _get_xy_from_wcs(self, data, quantity=False, linear=False):
         """Get the x,y axis vectors from the WCS of the input data.
 
-        :param data: the input image
-        :type data: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-        :param quantity: If True, return the arrays as :class:`astropy.units.Quantity`. If False, the returned arrays are :class:`numpy.ndarray`.
-        :type quantity: bool
-        :param linear: If True, returned arrays are in linear space, if False they are in log space.
-        :type linear: bool
-        :return: The axis values as arrays.  Values are center of pixel.
-        :rtype: :class:`numpy.ndarray` or :class:`astropy.units.Quantity`
+        Parameters
+        ----------
+        data : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+            The input image.
+        quantity : bool, optional
+            If True, return arrays as :class:`astropy.units.Quantity`. Default: False.
+        linear : bool, optional
+            If True, return arrays in linear space; if False, in log space. Default: False.
+
+        Returns
+        -------
+        :class:`numpy.ndarray` or :class:`astropy.units.Quantity`
+            The axis values as arrays. Values are center of pixel.
         """
         return utils.get_xy_from_wcs(data, quantity, linear)
 

--- a/pdrtpy/plot/plotbase.py
+++ b/pdrtpy/plot/plotbase.py
@@ -28,8 +28,12 @@ warnings.filterwarnings("ignore", message=".*do_format.*", category=RuntimeWarni
 class PlotBase:
     """Base class for plotting.
 
-    :param tool:  Reference to a :mod:`~pdrtpy.tool` object or `None`.  This is used for classes that inherit from PlotBase and are coupled to a specific tool, e.g. :class:`~pdrtpy.plot.LineRatioPlot` and :class:`~pdrtpy.tool.LineRatioFit`.
-    :type tool: Any class derived from :class:`~pdrtpy.tool.toolbase.ToolBase`
+    Parameters
+    ----------
+    tool : any class derived from :class:`~pdrtpy.tool.toolbase.ToolBase`
+        Reference to a :mod:`~pdrtpy.tool` object or ``None``. This is used for
+        classes that inherit from PlotBase and are coupled to a specific tool,
+        e.g. :class:`~pdrtpy.plot.LineRatioPlot` and :class:`~pdrtpy.tool.LineRatioFit`.
     """
 
     def __init__(self, tool):
@@ -70,15 +74,22 @@ class PlotBase:
     def _autolevels(self, data, steps="log", numlevels=None, verbose=False):
         """Compute contour levels automatically based on data.
 
-        :param data: The data to contour
-        :type data: numpy.ndarray, astropy.io.fits HDU or CCDData
-        :param steps: The type of steps to compute. "log" for logarithmic, or "lin" for linear. Defaut: log
-        :type steps: str
-        :param numlevels: The number of contour levels to compute. Default: None which means autocompute the number of levels which typically gives about 10 levels.
-        :type numlevels: int
-        :param verbose: Print the computed levels. Default: False
-        :type verbose: boolean
-        :returns:  numpy.array containing level values
+        Parameters
+        ----------
+        data : :class:`numpy.ndarray`, :mod:`astropy.io.fits` HDU, or CCDData
+            The data to contour.
+        steps : str, optional
+            The type of steps to compute: ``"log"`` for logarithmic, or ``"lin"`` for linear. Default: ``"log"``.
+        numlevels : int, optional
+            The number of contour levels to compute. Default: None, which means
+            autocompute (typically gives about 10 levels).
+        verbose : bool, optional
+            Print the computed levels. Default: False.
+
+        Returns
+        -------
+        :class:`numpy.ndarray`
+            Array containing level values.
         """
 
         # tip of the hat to the WIP autolevels code lev.
@@ -121,7 +132,9 @@ class PlotBase:
     def figure(self):
         """The last figure that was drawn.
 
-        :rtype: :class:`matplotlib.figure.Figure`
+        Returns
+        -------
+        :class:`matplotlib.figure.Figure`
         """
         return self._figure
 
@@ -129,36 +142,55 @@ class PlotBase:
     def axis(self):
         """The last axis that was drawn.
 
-        :rtype: :class:`matplotlib.axes._subplots.AxesSubplot`
+        Returns
+        -------
+        :class:`matplotlib.axes._subplots.AxesSubplot`
         """
         return self._axis
 
     def text(self, x, y, s, fontdict=None, **kwargs):
-        r"""
-        Add text to the Axes.  Add the text `s` to the Axes at location `x, y` in data coordinates.
-        This calls through to :meth:`matplotlib.pyplot.text`.
+        r"""Add text to the Axes at location ``x, y`` in data coordinates.
 
-        :param x: the horizontal coordinate for the text
-        :type x: float
-        :param y: the vertical coordinate for the text
-        :type y: float
-        :param s: the text
-        :type s: str
-        :param fontdict: A dictionary to override the default text properties. If fontdict is None, the defaults are determined by rcParams.
-        :type fontdict: dict
-        :param \*\*kwargs: Other miscellaneous :class:`~matplotlib.text.Text` parameters.
+        Calls through to :meth:`matplotlib.pyplot.text`.
+
+        Parameters
+        ----------
+        x : float
+            The horizontal coordinate for the text.
+        y : float
+            The vertical coordinate for the text.
+        s : str
+            The text.
+        fontdict : dict, optional
+            A dictionary to override the default text properties. If None,
+            the defaults are determined by rcParams.
+        \*\*kwargs
+            Other miscellaneous :class:`~matplotlib.text.Text` parameters.
         """
         self._plt.text(x, y, s, fontdict, **kwargs)
 
     def _zscale(self, image, vmin, vmax, stretch, contrast=0.25):
-        """Normalization object using Zscale algorithm
-           See :mod:`astropy.visualization.ZScaleInterval`
+        """Normalization object using Zscale algorithm.
 
-        :param image: the image object
-        :type image: :mod:`astropy.io.fits` HDU or CCDData
-        :param contrast: The scaling factor (between 0 and 1) for determining the minimum and maximum value. Larger values increase the difference between the minimum and maximum values used for display. Defaults to 0.25.
-        :type contrast: float
-        :returns: :mod:`astropy.visualization.normalization` object
+        See :mod:`astropy.visualization.ZScaleInterval`.
+
+        Parameters
+        ----------
+        image : :mod:`astropy.io.fits` HDU or CCDData
+            The image object.
+        vmin : float
+            Minimum value for normalization.
+        vmax : float
+            Maximum value for normalization.
+        stretch : str
+            Stretch type to apply.
+        contrast : float, optional
+            Scaling factor (0 to 1) for determining min/max display values.
+            Larger values increase the difference. Default: 0.25.
+
+        Returns
+        -------
+        :class:`astropy.visualization.ImageNormalize`
         """
         # clip=False required or NaNs get max color value, see https://github.com/astropy/astropy/issues/8165
         if stretch == "linear":
@@ -180,19 +212,24 @@ class PlotBase:
         return norm
 
     def _get_norm(self, norm, km, vmin, vmax, stretch):
-        """Get a Normalization object
+        """Get a Normalization object.
 
-        :param norm: The normalization time ( 'simple', 'zscale', 'log' )
-        :type norm: str
-        :param km: the image object
-        :type km: :mod:`astropy.io.fits` HDU or CCDData
-        :param vmin: the image minimum to use
-        :type vmin: float
-        :param vmax: the image maximum to use
-        :type vmax: float
-        :param stretch: the stretch to use (linear,log,power, asinh)
-        :type stretch: str
-        :returns: :mod:`astropy.visualization.normalization` object
+        Parameters
+        ----------
+        norm : str
+            The normalization type: ``'simple'``, ``'zscale'``, or ``'log'``.
+        km : :mod:`astropy.io.fits` HDU or CCDData
+            The image object.
+        vmin : float
+            The image minimum to use.
+        vmax : float
+            The image maximum to use.
+        stretch : str
+            The stretch to use: ``'linear'``, ``'log'``, ``'power'``, or ``'asinh'``.
+
+        Returns
+        -------
+        :class:`astropy.visualization.ImageNormalize` or :class:`matplotlib.colors.LogNorm`
         """
         if isinstance(norm, str):
             norm = norm.lower()
@@ -217,24 +254,26 @@ class PlotBase:
             return norm
 
     def _wcs_colorbar(self, image, axis, pos="right", width="5%", pad=0.05, orientation="vertical"):
-        """Create a colorbar for a subplot with WCSAxes
-        (as opposed to matplolib Axes).  There are some side-effects of
-        using WCS projection that need to be ameliorated.  Also for
-        subplots, we want the colorbars to have the same height as the
-        plot, which is not the default behavior.
+        """Create a colorbar for a subplot with WCSAxes (as opposed to matplotlib Axes).
 
-        :param image: the mappable object for the plot. Must not be masked.
-        :type image: :obj:`numpy.ndarray`,:mod:`astropy.io.fits` HDU or CCDData
-        :param axis: which Axes object for the plot
-        :type axis:  :class:`matplotlib.axis.Axes`
-        :param pos: colorbar position: ["left"|"right"|"bottom"|"top"]. Default: right
-        :type pos: str
-        :param width: width of the colorbar in terms of percent width of the plot.
-        :type width: str
-        :param pad: padding between colorbar and plot, in inches.
-        :type pad: float
-        :param orientation: orientation of colorbar ["vertical" | "horizontal" ]
-        :type orientation: str
+        There are some side-effects of using WCS projection that need to be
+        ameliorated. Also for subplots, we want the colorbars to have the same
+        height as the plot, which is not the default behavior.
+
+        Parameters
+        ----------
+        image : :class:`numpy.ndarray`, :mod:`astropy.io.fits` HDU, or CCDData
+            The mappable object for the plot. Must not be masked.
+        axis : :class:`matplotlib.axis.Axes`
+            Which Axes object for the plot.
+        pos : str, optional
+            Colorbar position: ``"left"``, ``"right"``, ``"bottom"``, or ``"top"``. Default: ``"right"``.
+        width : str, optional
+            Width of the colorbar as a percent of the plot width. Default: ``"5%"``.
+        pad : float, optional
+            Padding between colorbar and plot, in inches. Default: 0.05.
+        orientation : str, optional
+            Orientation of colorbar: ``"vertical"`` or ``"horizontal"``. Default: ``"vertical"``.
         """
         divider = make_axes_locatable(axis)
         cax = divider.append_axes(pos, size=width, pad=pad, axes_class=maxes.Axes)
@@ -269,32 +308,43 @@ class PlotBase:
     def savefig(self, fname, **kwargs):
         """Save the current figure to a file.
 
-        :param fname: filename to save in
-        :type fname: str
-
-        :Keyword Arguments:
-
-        Additional arguments (**kwargs) are passed to :meth:`matplotlib.pyplot.savefig`. e.g., **bbox_inches='tight'** for a tight layout.
-
+        Parameters
+        ----------
+        fname : str
+            Filename to save to.
+        **kwargs
+            Additional arguments passed to :meth:`matplotlib.pyplot.savefig`,
+            e.g. ``bbox_inches='tight'`` for a tight layout.
         """
         kwargs_opts = {"bbox_inches": "tight", "transparent": False, "facecolor": "white"}
         kwargs_opts.update(kwargs)
         self._figure.savefig(fname=fname, **kwargs_opts)
 
     def usetex(self, use):
-        """Control whether plots delegate rendering of fancy text components in axis labels and elsewhere to the system version of LaTeX or use matplotlib's rendering. This method sets
-        matplotlib parameter `rcParams["text.usetex"]` in the local pyplot instance.  Note: You must have LaTeX installed on your system if setting this to True or an exception will be raised when you try to plot.
+        """Control whether plots delegate rendering to the system LaTeX or use matplotlib's rendering.
 
-        :param use: whether to use LaTeX or not
-        :type use: bool
+        Sets matplotlib parameter ``rcParams["text.usetex"]`` in the local pyplot instance.
+        Note: You must have LaTeX installed if setting this to True or an exception will be
+        raised when you try to plot.
+
+        Parameters
+        ----------
+        use : bool
+            Whether to use LaTeX or not.
         """
         self._plt.rcParams["text.usetex"] = use
 
     def colorcycle(self, colorcycle):
-        """Set the plot color cycle for multi-trace plots.  The default color cycle is optimized for color-blind users.
+        """Set the plot color cycle for multi-trace plots.
 
-        :param colorcycle: List of colors to use, typically a list of hex color strings.  This list will be passed to :meth:`matplotlib.pyplot.rc` as the *axes prop_cycle* parameter using :class:`matplotlib.cycler`.
-        :type colorcycle: list
+        The default color cycle is optimized for color-blind users.
+
+        Parameters
+        ----------
+        colorcycle : list
+            List of colors to use, typically hex color strings. Passed to
+            :meth:`matplotlib.pyplot.rc` as the *axes prop_cycle* parameter
+            using :class:`matplotlib.cycler`.
         """
         self._plt.rc("axes", prop_cycle=(cycler("color", colorcycle)))
 

--- a/pdrtpy/tool/excitation.py
+++ b/pdrtpy/tool/excitation.py
@@ -1658,7 +1658,7 @@ class BaseExcitationFit(ToolBase):
 # ========================== DERIVED CLASSES FOR SPECIFIC MOLECULES ===================================
 class H2ExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v`, and ortho-to-para ratio(`OPR`) from an :math:`H_2`
+        r"""Tool for fitting temperatures, column densities, :math:`A_v`, and ortho-to-para ratio(`OPR`) from an :math:`H_2`
         excitation diagram. It takes as input a set of :math:`H_2` rovibrational line observations with errors
         represented as :class:`~pdrtpy.measurement.Measurement`.
 
@@ -1681,7 +1681,7 @@ class H2ExcitationFit(BaseExcitationFit):
 
 class COExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{16}O` excitation diagram. It takes as input a set of :math:`^{12}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, :math:`A_v` from an :math:`^{12}C^{16}O` excitation diagram. It takes as input a set of :math:`^{12}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low `J` transitions and the hot gas dominates in the high `J` transitions.
@@ -1702,7 +1702,7 @@ class COExcitationFit(BaseExcitationFit):
 
 class C13OExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{16}O` excitation diagram. It takes as input a set of :math:`^{13}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, :math:`A_v` from an :math:`^{13}C^{16}O` excitation diagram. It takes as input a set of :math:`^{13}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1722,7 +1722,7 @@ class C13OExcitationFit(BaseExcitationFit):
 
 class CO18ExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{18}O` excitation diagram. It takes as input a set of :math:`^{12}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, :math:`A_v` from an :math:`^{12}C^{18}O` excitation diagram. It takes as input a set of :math:`^{12}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1742,7 +1742,7 @@ class CO18ExcitationFit(BaseExcitationFit):
 
 class C13O18ExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{18}O` excitation diagram. It takes as input a set of :math:`^{13}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, :math:`A_v` from an :math:`^{13}C^{18}O` excitation diagram. It takes as input a set of :math:`^{13}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1762,7 +1762,7 @@ class C13O18ExcitationFit(BaseExcitationFit):
 
 class CHplusExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v`, and ortho-to-para ratio(`OPR`) from an :math:`CH^{+}` excitation diagram. It takes as input a set of :math:`CH^{+}` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, :math:`A_v`, and ortho-to-para ratio(`OPR`) from an :math:`CH^{+}` excitation diagram. It takes as input a set of :math:`CH^{+}` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions. Given data over several transitions, one can fit for :math:`T_{cold}, T_{hot}, N_{total} = N_{cold}+ N_{hot}`. One needs at least 5 points to fit the temperatures and column densities (slope and intercept :math:`\times 2`), though one could compute (not fit) them with only 4 points.
 

--- a/pdrtpy/tool/excitation.py
+++ b/pdrtpy/tool/excitation.py
@@ -188,8 +188,10 @@ class BaseExcitationFit(ToolBase):
     def _init_measurements(self, m: list):
         r"""Initialize measurements dictionary given a list.
 
-        :param m: list of intensity :class:`~pdrtpy.measurement.Measurement`s in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`
-        :type m: list of :class:`~pdrtpy.measurement.Measurement`
+        Parameters
+        ----------
+        m : list of :class:`~pdrtpy.measurement.Measurement`
+            List of intensity measurements in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`.
         """
         self._measurements = dict()
         for mm in m:
@@ -218,10 +220,14 @@ class BaseExcitationFit(ToolBase):
 
         **If the molecule does not have a variable OPR, then all indices for the `ids` are returned.**
 
-        :param ids:
-        :type ids: list of str
-        :returns: The array indices of the odd J values.
-        :rtype: list of int
+        Parameters
+        ----------
+        ids : list of str
+
+        Returns
+        -------
+        list of int
+            The array indices of the odd J values.
         """
         if not self.molecule.opr_can_vary:
             # log.warning(f"The molecule {self.molecule.name} does not have a variable OPR.")
@@ -234,10 +240,14 @@ class BaseExcitationFit(ToolBase):
 
         **If the molecule does not have a variable OPR, then all indices for the `ids` are returned.**
 
-        :param ids:
-        :type ids: list of str
-        :returns: The array indices of the even J values.
-        :rtype: list of int
+        Parameters
+        ----------
+        ids : list of str
+
+        Returns
+        -------
+        list of int
+            The array indices of the even J values.
         """
         if not self.molecule.opr_can_vary:
             log.warning(f"The molecule {self.molecule.name} does not have a variable OPR.")
@@ -252,7 +262,10 @@ class BaseExcitationFit(ToolBase):
         compute the excitation diagram.   This method can also be used
         to safely replace an existing intensity Measurement.
 
-        :param m: A :class:`~pdrtpy.measurement.Measurement` instance containing intensity in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`
+        Parameters
+        ----------
+        m : :class:`~pdrtpy.measurement.Measurement`
+            A measurement instance containing intensity in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`.
         """
         if not utils.check_units(m.unit, self._intensity_units):
             raise TypeError(
@@ -269,9 +282,15 @@ class BaseExcitationFit(ToolBase):
     def remove_measurement(self, identifier: str):
         """Delete a measurement from the internal dictionary used to compute column densities. Any associated column density will also be removed.
 
-        :param identifier: the measurement identifier
-        :type identifier: str
-        :raises KeyError: if identifier not in existing Measurements
+        Parameters
+        ----------
+        identifier : str
+            The measurement identifier.
+
+        Raises
+        ------
+        KeyError
+            If identifier not in existing Measurements.
         """
         del self._measurements[identifier]  # we want this to raise a KeyError if id not found
         self._column_density.pop(identifier, None)  # but not this.
@@ -281,7 +300,10 @@ class BaseExcitationFit(ToolBase):
         change a Measurement in place, use this method.
         Otherwise, the column densities will be inconsistent.
 
-        :param m: A :class:`~pdrtpy.measurement.Measurement` instance containing intensity in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`
+        Parameters
+        ----------
+        m : :class:`~pdrtpy.measurement.Measurement`
+            A measurement instance containing intensity in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`.
         """
         self.add_measurement(m)
 
@@ -306,39 +328,46 @@ class BaseExcitationFit(ToolBase):
         r"""Fit the :math:`log N_u-E` diagram with two excitation temperatures,
         a ``hot`` :math:`T_{ex}` and a ``cold`` :math:`T_{ex}`.
 
-        If ``position`` and ``size`` are given, the data will be averaged over a spatial box before fitting.  The box is created using :class:`astropy.nddata.utils.Cutout2D`.  If position or size is None, the data are averaged over all pixels.  If the Measurements are single values, these arguments are ignored.
+        If ``position`` and ``size`` are given, the data will be averaged over a spatial box before fitting.
+        The box is created using :class:`astropy.nddata.utils.Cutout2D`. If position or size is None,
+        the data are averaged over all pixels. If the Measurements are single values, these arguments are ignored.
 
-        :param position: The position of the cutout array's center with respect to the data array. The position can be specified either as a `(x, y)` tuple of pixel coordinates.
-        :type position: tuple
-        :param size: The size of the cutout array along each axis in pixels. If size is a scalar number or a scalar :class:`~astropy.units.Quantity`, then a square cutout of size will be created. If `size` has two elements, they should be in `(nx, ny)` order [*this is the opposite of Cutout2D signature*]. Scalar numbers in size are assumed to be in units of pixels.  Default value of None means use all pixels (position is ignored)
-        :type size: int, array_like`
-        :param fit_opr: Whether to fit the ortho-to-para ratio or not. If True, the OPR will be varied to determine the best value. If False, the OPR is fixed at the canonical LTE value of 3.
-        :type fit_opr: bool
-        :param fit_av: Whether to fit the visual extinction. If True, the Av will be varied to determine the best value. If False, the Av is fixed at zero.
-        :type fit_av: bool
-        :param workers: Number of worker processes for parallel pixel fitting.  ``None``
-            (default) runs serially.  ``-1`` uses all available CPUs.  Any positive
-            integer uses that many workers.  Matches the ``LineRatioFit.run()`` API.
+        Parameters
+        ----------
+        position : tuple
+            The position of the cutout array's center with respect to the data array. The position can
+            be specified either as a `(x, y)` tuple of pixel coordinates.
+        size : int or array_like
+            The size of the cutout array along each axis in pixels. If size is a scalar number or a
+            scalar :class:`~astropy.units.Quantity`, then a square cutout of size will be created. If
+            `size` has two elements, they should be in `(nx, ny)` order [*this is the opposite of
+            Cutout2D signature*]. Scalar numbers in size are assumed to be in units of pixels. Default
+            value of None means use all pixels (position is ignored).
+        fit_opr : bool
+            Whether to fit the ortho-to-para ratio or not. If True, the OPR will be varied to determine
+            the best value. If False, the OPR is fixed at the canonical LTE value of 3.
+        fit_av : bool
+            Whether to fit the visual extinction. If True, the Av will be varied to determine the best
+            value. If False, the Av is fixed at zero.
+        workers : int or None
+            Number of worker processes for parallel pixel fitting. ``None`` (default) runs serially.
+            ``-1`` uses all available CPUs. Any positive integer uses that many workers. Matches the
+            ``LineRatioFit.run()`` API.
 
             **Performance note**: each pixel is submitted as a separate task to
-            :class:`~concurrent.futures.ProcessPoolExecutor`, so inter-process
-            communication overhead is paid once per pixel.  For the excitation fits
-            in this package (n ≤ ~20 spectral lines, lightweight lmfit minimisation)
-            the per-pixel compute time is short enough that parallel execution only
-            outperforms serial on maps with roughly 5 000 or more *valid* (unmasked)
-            pixels.  On smaller maps the IPC overhead dominates and serial is faster.
+            :class:`~concurrent.futures.ProcessPoolExecutor`, so inter-process communication overhead
+            is paid once per pixel. For the excitation fits in this package (n ≤ ~20 spectral lines,
+            lightweight lmfit minimisation) the per-pixel compute time is short enough that parallel
+            execution only outperforms serial on maps with roughly 5 000 or more *valid* (unmasked)
+            pixels. On smaller maps the IPC overhead dominates and serial is faster.
 
-            ``emcee`` fitting is excluded from the parallel path regardless of
-            this setting.
-        :type workers: int or None
-        :param chunk_size: Number of pixels batched into each parallel task
-            (default: 32).  Each worker process fits ``chunk_size`` pixels
-            serially, so IPC serialisation overhead is paid once per chunk
-            rather than once per pixel.  Larger values reduce overhead further
-            but coarsen progress-bar granularity and may cause load imbalance
-            on the last chunk.  Ignored when ``workers`` is ``None`` or when
-            the fitting method is ``'emcee'``.
-        :type chunk_size: int
+            ``emcee`` fitting is excluded from the parallel path regardless of this setting.
+        chunk_size : int
+            Number of pixels batched into each parallel task (default: 32). Each worker process fits
+            ``chunk_size`` pixels serially, so IPC serialisation overhead is paid once per chunk rather
+            than once per pixel. Larger values reduce overhead further but coarsen progress-bar
+            granularity and may cause load imbalance on the last chunk. Ignored when ``workers`` is
+            ``None`` or when the fitting method is ``'emcee'``.
         """
         # @todo what happens if e.g., fit_av=True and init_av !=0 ?
         kwargs_opts = {
@@ -416,7 +445,9 @@ class BaseExcitationFit(ToolBase):
     def fit_result(self):
         """The result of the fitting procedure which includes fit statistics, variable values and uncertainties, and correlations between variables.
 
-        :rtype:  :class:`lmfit.model.ModelResult`
+        Returns
+        -------
+        :class:`lmfit.model.ModelResult`
         """
         return self._fitresult
 
@@ -424,7 +455,9 @@ class BaseExcitationFit(ToolBase):
     def numcomponents(self):
         """Number of temperature components in the fit
 
-        :rtype: int
+        Returns
+        -------
+        int
         """
         return self._numcomponents
 
@@ -432,8 +465,10 @@ class BaseExcitationFit(ToolBase):
     def av_fitted(self):
         """Was the visual extinction fitted?
 
-        :returns: True if Av was fitted, False if not
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if Av was fitted, False if not.
         """
         if self._fitresult is None:
             return False
@@ -443,8 +478,10 @@ class BaseExcitationFit(ToolBase):
     def av(self):
         """The visual extinction
 
-        :returns: The fitted Av if it was determined in the fit, otherwise 0
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
+            The fitted Av if it was determined in the fit, otherwise 0.
         """
         return self._av
 
@@ -452,8 +489,10 @@ class BaseExcitationFit(ToolBase):
     def opr_fitted(self):
         """Was the ortho-to-para ratio fitted?
 
-        :returns: True if OPR was fitted, False if canonical LTE value was used or this molecule's OPR canno vary.
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if OPR was fitted, False if canonical LTE value was used or this molecule's OPR cannot vary.
         """
         if not self.molecule.opr_can_vary:
             return False
@@ -465,8 +504,10 @@ class BaseExcitationFit(ToolBase):
     def opr(self):
         """The ortho-to-para ratio (OPR)
 
-        :returns: The fitted OPR if it was determined in the fit, otherwise the canonical LTE OPR
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
+            The fitted OPR if it was determined in the fit, otherwise the canonical LTE OPR.
         """
         return self._opr
 
@@ -487,7 +528,9 @@ class BaseExcitationFit(ToolBase):
     def intensities(self):
         """The stored intensities. See :meth:`add_measurement`
 
-        :rtype: list of :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        list of :class:`~pdrtpy.measurement.Measurement`
         """
         return self._measurements
 
@@ -495,7 +538,9 @@ class BaseExcitationFit(ToolBase):
     def total_colden(self):
         """The fitted total column density
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         if self._numcomponents == 1:
             return self._total_colden["cold"]
@@ -505,7 +550,9 @@ class BaseExcitationFit(ToolBase):
     def hot_colden(self):
         """The fitted hot gas total column density
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._total_colden["hot"]
 
@@ -513,7 +560,9 @@ class BaseExcitationFit(ToolBase):
     def cold_colden(self):
         """The fitted cold gas total column density
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._total_colden["cold"]
 
@@ -521,7 +570,9 @@ class BaseExcitationFit(ToolBase):
     def tcold(self):
         """The fitted cold gas excitation temperature
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._temperature["cold"]  # self._fitparams.tcold
 
@@ -529,14 +580,19 @@ class BaseExcitationFit(ToolBase):
     def thot(self):
         """The fitted hot gas excitation temperature
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._temperature["hot"]  # self._fitparams.thot
 
     @property
     def temperature(self):
         """The fitted gas temperatures, returned in a dictionary with keys 'hot' and 'cold'.
-        :rtype: dict
+
+        Returns
+        -------
+        dict
         """
         return self._temperature
 
@@ -560,10 +616,14 @@ class BaseExcitationFit(ToolBase):
     def colden(self, component):  # ,log=False):
         """The column density of hot or cold gas component, or total column density.
 
-        :param component: 'hot', 'cold', or 'total
-        :type component: str
+        Parameters
+        ----------
+        component : str
+            'hot', 'cold', or 'total'.
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         #:param log: take the log10 of the column density
         cl = component.lower()
@@ -577,18 +637,21 @@ class BaseExcitationFit(ToolBase):
     def column_densities(self, norm=False, unit=utils._CM2, line=True):
         r"""The computed upper state column densities of stored intensities
 
-        :param norm: if True, normalize the column densities by the
-                    statistical weight of the upper state, :math:`g_u`.
-                    Default: False
-        :type norm: bool
-        :param unit: The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`
-        :type unit: str or :class:`astropy.units.Unit`
-        :param line: if True, the dictionary index is the Line name,
-                  otherwise it is the upper state :math:`J` number.  Default: False
-        :type line: bool
+        Parameters
+        ----------
+        norm : bool
+            If True, normalize the column densities by the statistical weight of the upper state,
+            :math:`g_u`. Default: False.
+        unit : str or :class:`astropy.units.Unit`
+            The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`.
+        line : bool
+            If True, the dictionary index is the Line name, otherwise it is the upper state
+            :math:`J` number. Default: True.
 
-        :returns: dictionary of column densities indexed by upper state :math:`J` number or Line name. Default: False means return indexed by :math:`J`.
-        :rtype: dict
+        Returns
+        -------
+        dict
+            Dictionary of column densities indexed by upper state :math:`J` number or Line name.
         """
         # Compute column densities if needed.
         # Note: this has a gotcha - if user changes an existing intensity
@@ -630,21 +693,35 @@ class BaseExcitationFit(ToolBase):
     ):
         r"""Compute the average column density over a spatial box.  The box is created using :class:`astropy.nddata.utils.Cutout2D`.
 
-        :param position: The position of the cutout array's center with respect to the data array. The position can be specified either as a `(x, y)` tuple of pixel coordinates.
-        :type position: tuple
-        :param size: The size of the cutout array along each axis. If size is a scalar number or a scalar :class:`~astropy.units.Quantity`, then a square cutout of size will be created. If `size` has two elements, they should be in `(nx,ny)` order [*this is the opposite of Cutout2D signature*]. Scalar numbers in size are assumed to be in units of pixels.  Default value of None means use all pixels (position is ignored)
-        :type size: int, array_like`
-        :param norm: if True, normalize the column densities by the
-                       statistical weight of the upper state, :math:`g_u`.  For ortho-:math:`H_2`, :math:`g_u = OPR \times (2J+1)`, for para-:math:`H_2`, :math:`g_u=2J+1`. In LTE, :math:`OPR = 3`.
-        :type norm: bool
-        :param unit: The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`
-        :type unit: str or :class:`astropy.units.Unit`
-        :param line: if True, the returned dictionary index is the Line name, otherwise it is the upper state :math:`J` number.
-        :type line: bool
-        :returns: dictionary of column density Measurements, with keys as :math:`J` number or Line name
-        :rtype:  dict
-        :param clip: Column density value at which to clip pixels. Pixels with column densities below this value will not be used in the average. Default: a large negative number, which translates to no clipping.
-        :type clip: :class:`astropy.units.Quantity`
+        Parameters
+        ----------
+        position : tuple
+            The position of the cutout array's center with respect to the data array. The position can
+            be specified either as a `(x, y)` tuple of pixel coordinates.
+        size : int or array_like
+            The size of the cutout array along each axis. If size is a scalar number or a scalar
+            :class:`~astropy.units.Quantity`, then a square cutout of size will be created. If `size`
+            has two elements, they should be in `(nx,ny)` order [*this is the opposite of Cutout2D
+            signature*]. Scalar numbers in size are assumed to be in units of pixels. Default value of
+            None means use all pixels (position is ignored).
+        norm : bool
+            If True, normalize the column densities by the statistical weight of the upper state,
+            :math:`g_u`. For ortho-:math:`H_2`, :math:`g_u = OPR \times (2J+1)`, for
+            para-:math:`H_2`, :math:`g_u=2J+1`. In LTE, :math:`OPR = 3`.
+        unit : str or :class:`astropy.units.Unit`
+            The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`.
+        line : bool
+            If True, the returned dictionary index is the Line name, otherwise it is the upper state
+            :math:`J` number.
+        clip : :class:`astropy.units.Quantity`
+            Column density value at which to clip pixels. Pixels with column densities below this value
+            will not be used in the average. Default: a large negative number, which translates to no
+            clipping.
+
+        Returns
+        -------
+        dict
+            Dictionary of column density Measurements, with keys as :math:`J` number or Line name.
         """
         # @todo
         # - should default clip = None?
@@ -718,11 +795,16 @@ class BaseExcitationFit(ToolBase):
         # @todo remove unit if transition_data is changed to QTable
         r"""Upper state energies of stored intensities, in K.
 
-        :param line: if True, the dictionary index is the Line name,
-                  otherwise it is the upper state :math:`J` number.  Default: False
-        :type line: bool
-        :returns: dictionary indexed by upper state :math:`J` number or Line name. Default: False means return indexed by :math:`J`.
-        :rtype: dict
+        Parameters
+        ----------
+        line : bool
+            If True, the dictionary index is the Line name, otherwise it is the upper state
+            :math:`J` number. Default: True.
+
+        Returns
+        -------
+        dict
+            Dictionary indexed by upper state :math:`J` number or Line name.
         """
         t = dict()
         if line:
@@ -736,13 +818,18 @@ class BaseExcitationFit(ToolBase):
     def wavelengths(self, line=True, units=False):
         r"""Wavelengths of transitions, in micron (assumed unit using Roueff et al table)
 
-        :param line: if True, the dictionary index is the Line name,
-                  otherwise it is the upper state :math:`J` number.  Default: False
-        :type line: bool
-        :param units: if True, values are returned with units as astropy Quantity
-        :type units: bool
-        :returns: dictionary indexed by upper state :math:`J` number or Line name. Default: False means return indexed by :math:`J`.
-        :rtype: dict
+        Parameters
+        ----------
+        line : bool
+            If True, the dictionary index is the Line name, otherwise it is the upper state
+            :math:`J` number. Default: True.
+        units : bool
+            If True, values are returned with units as astropy Quantity.
+
+        Returns
+        -------
+        dict
+            Dictionary indexed by upper state :math:`J` number or Line name.
         """
         # @todo remove unit if transition_data is changed to QTable
         t = dict()
@@ -759,14 +846,23 @@ class BaseExcitationFit(ToolBase):
         return t
 
     def gu(self, id, opr):
-        r"""Get the upper state statistical weight :math:`g_u` for the given transition identifer, and, if the transition is odd-:math:`J`, scale the result by the given ortho-to-para ratio.  If the transition is even-:math:`J`, the LTE value is returned.
+        r"""Get the upper state statistical weight :math:`g_u` for the given transition identifier, and, if the transition is odd-:math:`J`, scale the result by the given ortho-to-para ratio.  If the transition is even-:math:`J`, the LTE value is returned.
 
-        :param id: the measurement identifier
-        :type id: str
-        :param opr:
-        :type opr: float
-        :raises KeyError: if `id` not in existing Measurements
-        :rtype: float
+        Parameters
+        ----------
+        id : str
+            The measurement identifier.
+        opr : float
+            Ortho-to-para ratio.
+
+        Returns
+        -------
+        float
+
+        Raises
+        ------
+        KeyError
+            If `id` not in existing Measurements.
         """
         if not self.molecule.opr_can_vary:
             log.warning(f"The molecule {self.molecule.name} does not have a variable OPR.")
@@ -785,10 +881,15 @@ class BaseExcitationFit(ToolBase):
 
         where :math:`A` is the Einstein A coefficient and :math:`\Delta E` is the energy of the transition.
 
-        :param colden: upper state column density
-        :type colden: :class:`~pdrtpy.measurement.Measurement`
-        :returns: optically thin intensity
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Parameters
+        ----------
+        colden : :class:`~pdrtpy.measurement.Measurement`
+            Upper state column density.
+
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
+            Optically thin intensity.
         """
         # colden is N_upper
         # @todo remove unit if transition_data is changed to QTable
@@ -818,12 +919,18 @@ class BaseExcitationFit(ToolBase):
 
         where :math:`A` is the Einstein A coefficient and :math:`\Delta E` is the energy of the transition.
 
-        :param intensity: A :class:`~pdrtpy.measurement.Measurement` instance containing intensity in units equivalent to :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`
-        :type intensity: :class:`~pdrtpy.measurement.Measurement`
-        :param unit: The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`
-        :type unit: str or :class:`astropy.units.Unit`
-        :returns: a :class:`~pdrtpy.measurement.Measurement` of the column density.
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Parameters
+        ----------
+        intensity : :class:`~pdrtpy.measurement.Measurement`
+            A measurement instance containing intensity in units equivalent to
+            :math:`{\rm erg~cm^{-2}~s^{-1}~sr^{-1}}`.
+        unit : str or :class:`astropy.units.Unit`
+            The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`.
+
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
+            The column density.
         """
         # suppress ridiculous NDDATA warning about units. See issue #163
         log.setLevel("WARNING")
@@ -843,16 +950,14 @@ class BaseExcitationFit(ToolBase):
 
     def _compute_column_densities(self, unit=utils._CM2, line=True):
         r"""Compute all upper level column densities for stored intensity measurements and puts them in a dictionary
-        :param unit: The units in which to return the column density. Default: :math:`{\rm }cm^{-2}`
-        :type unit: str or :class:`astropy.units.Unit`
-        :param line: if True, the dictionary index is the Line name,
-                  otherwise it is the upper state :math:`J` number.  Default: False
-        :type line: bool
 
-         # should we reutrn something here or just compute them and never store.
-         # I'm beginning to think there is no reason to store them.
-        #:returns: dictionary of column densities as:class:`~pdrtpy.measurement.Measurement  indexed by upper state :math:`J` number or Line name. Default: False means return indexed by :math:`J`.
-        #:returns: a :class:`~pdrtpy.measurement.Measurement` of the column density.
+        Parameters
+        ----------
+        unit : str or :class:`astropy.units.Unit`
+            The units in which to return the column density. Default: :math:`{\rm cm}^{-2}`.
+        line : bool
+            If True, the dictionary index is the Line name, otherwise it is the upper state
+            :math:`J` number. Default: True.
         """
         self._column_density = dict()
         for m in self._measurements:
@@ -1002,12 +1107,14 @@ class BaseExcitationFit(ToolBase):
     def _one_line(self, x, m1, n1):
         """Return a line.
 
-        :param x: array of x values
-        :type x: :class:`numpy.ndarray`
-        :param m1: slope of first line
-        :type m1: float
-        :param n1: intercept of first line
-        :type n1: float
+        Parameters
+        ----------
+        x : :class:`numpy.ndarray`
+            Array of x values.
+        m1 : float
+            Slope of first line.
+        n1 : float
+            Intercept of first line.
         """
         return m1 * x + n1
 
@@ -1058,11 +1165,18 @@ class BaseExcitationFit(ToolBase):
         Benchmarks confirm SSR is 3–5× faster than PELT for n = 7 across a 2655-pixel
         CenA map, with identical breakpoint selections on well-behaved spectra.
 
-        :param x: 1-D energy array (n_lines,)
-        :param y_1d: 1-D log column-density array (n_lines,)
-        :returns: breakpoint index *bp* such that the cold segment is ``y_1d[:bp]``
-                  and the hot segment is ``y_1d[bp:]``, with ``2 ≤ bp ≤ n-2``.
-        :rtype: int
+        Parameters
+        ----------
+        x : array_like
+            1-D energy array (n_lines,).
+        y_1d : array_like
+            1-D log column-density array (n_lines,).
+
+        Returns
+        -------
+        int
+            Breakpoint index *bp* such that the cold segment is ``y_1d[:bp]``
+            and the hot segment is ``y_1d[bp:]``, with ``2 ≤ bp ≤ n-2``.
         """
         n = len(y_1d)
         # Prefix sums (length n+1; index 0 is zero by construction)
@@ -1112,10 +1226,17 @@ class BaseExcitationFit(ToolBase):
         Falls back to :meth:`_find_breakpoint_ssr` if PELT does not return
         exactly one interior breakpoint.
 
-        :param x: 1-D energy array (n_lines,)
-        :param y_1d: 1-D log column-density array (n_lines,)
-        :returns: breakpoint index bp such that cold segment = y_1d[:bp], hot = y_1d[bp:]
-        :rtype: int
+        Parameters
+        ----------
+        x : array_like
+            1-D energy array (n_lines,).
+        y_1d : array_like
+            1-D log column-density array (n_lines,).
+
+        Returns
+        -------
+        int
+            Breakpoint index bp such that cold segment = y_1d[:bp], hot = y_1d[bp:].
         """
         n = len(y_1d)
         signal = y_1d.reshape(-1, 1)
@@ -1135,8 +1256,10 @@ class BaseExcitationFit(ToolBase):
     def _fit_segment(self, x_seg, y_seg):
         """Fit a line to (x_seg, y_seg) via polyfit; enforce negative slope.
 
-        :returns: (slope, rss, intercept, residuals_sum)
-        :rtype: tuple
+        Returns
+        -------
+        tuple
+            (slope, rss, intercept, residuals_sum).
         """
         coeffs = np.polyfit(x_seg, y_seg, 1)
         slope, intercept = coeffs
@@ -1150,14 +1273,21 @@ class BaseExcitationFit(ToolBase):
     def _ruptures_partition(self, x, yr, partition_method="ssr"):
         """Partition each pixel spectrum and fit segments to get initial guesses.
 
-        :param x: 1-D energy array (n_lines,)
-        :param yr: 2-D array (n_lines, n_pix) of log column densities
-        :param partition_method: breakpoint-finding algorithm, ``"ssr"`` (default) or
-            ``"pelt"``.  ``"ssr"`` uses a vectorised prefix-sum search
-            (see :meth:`_find_breakpoint_ssr`); ``"pelt"`` uses the ruptures library
-            (see :meth:`_find_breakpoint_pelt`).
-        :type partition_method: str
-        :returns: (slopecold, intcold, slopehot, inthot) each shape (n_pix,)
+        Parameters
+        ----------
+        x : array_like
+            1-D energy array (n_lines,).
+        yr : array_like
+            2-D array (n_lines, n_pix) of log column densities.
+        partition_method : str
+            Breakpoint-finding algorithm, ``"ssr"`` (default) or ``"pelt"``. ``"ssr"`` uses a
+            vectorised prefix-sum search (see :meth:`_find_breakpoint_ssr`); ``"pelt"`` uses the
+            ruptures library (see :meth:`_find_breakpoint_pelt`).
+
+        Returns
+        -------
+        tuple
+            (slopecold, intcold, slopehot, inthot) each shape (n_pix,).
         """
         find_bp = self._find_breakpoint_pelt if partition_method == "pelt" else self._find_breakpoint_ssr
         n_pix = yr.shape[1]
@@ -1196,10 +1326,16 @@ class BaseExcitationFit(ToolBase):
         are both given, the data are averaged over a spatial box (``Cutout2D``)
         before fitting; otherwise every pixel is fit independently.
 
-        :param position: ``(x, y)`` pixel coordinate or :class:`~astropy.coordinates.SkyCoord`.
-        :param size: scalar pixel size or ``(nx, ny)`` tuple.
-        :param fit_opr: vary the ortho-to-para ratio.
-        :param fit_av: vary the visual extinction.
+        Parameters
+        ----------
+        position : tuple or :class:`~astropy.coordinates.SkyCoord`
+            ``(x, y)`` pixel coordinate.
+        size : int or tuple
+            Scalar pixel size or ``(nx, ny)`` tuple.
+        fit_opr : bool
+            Vary the ortho-to-para ratio.
+        fit_av : bool
+            Vary the visual extinction.
         """
         verbose = kwargs.pop("verbose")
         partition_method = kwargs.pop("partition_method", "ssr")
@@ -1535,16 +1671,17 @@ class H2ExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`H_2` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`H_2` measurements to be fit.
         """
         super().__init__(mol.H2(), measurements)
 
 
 class COExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{16}O` excitation diagram. It takes as input a set of :math:`H_2` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
-
+        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{16}O` excitation diagram. It takes as input a set of :math:`^{12}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low `J` transitions and the hot gas dominates in the high `J` transitions.
@@ -1555,15 +1692,17 @@ class COExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`^{12}CO` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`^{12}CO` measurements to be fit.
         """
         super().__init__(mol.CO(), measurements)
 
 
 class C13OExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{16}O` excitation diagram. It takes as input a set of :math:`H_2` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{16}O` excitation diagram. It takes as input a set of :math:`^{13}CO` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1573,15 +1712,17 @@ class C13OExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`^{13}CO` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`^{13}CO` measurements to be fit.
         """
         super().__init__(mol.C13O(), measurements)
 
 
 class CO18ExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{18}O` excitation diagram. It takes as input a set of :math:`H_2` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{12}C^{18}O` excitation diagram. It takes as input a set of :math:`^{12}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1591,15 +1732,17 @@ class CO18ExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`^{12}C^{18}O` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`^{12}C^{18}O` measurements to be fit.
         """
         super().__init__(mol.CO18(), measurements)
 
 
 class C13O18ExcitationFit(BaseExcitationFit):
     def __init__(self, measurements: Measurement = None):
-        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{18}O` excitation diagram. It takes as input a set of :math:`H_2` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
+        r"""Tool for fitting temperatures, column densities, `A_v` from an :math:`^{13}C^{18}O` excitation diagram. It takes as input a set of :math:`^{13}C^{18}O` rovibrational line observations with errors represented as :class:`~pdrtpy.measurement.Measurement`.
 
         Often, excitation diagrams show evidence of both "hot" and "cold" gas components, where the cold gas
         dominates the intensity in the low :math:`J` transitions and the hot gas dominates in the high :math:`J` transitions.
@@ -1609,8 +1752,10 @@ class C13O18ExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`^{13}C^{18}O` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`^{13}C^{18}O` measurements to be fit.
         """
         super().__init__(mol.CO18(), measurements)
 
@@ -1623,7 +1768,9 @@ class CHplusExcitationFit(BaseExcitationFit):
 
         Once the fit is done, :class:`~pdrtpy.plot.ExcitationPlot` can be used to view the results.
 
-        :param measurements: Input :math:`CH^{+}` measurements to be fit.
-        :type measurements: list of :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        measurements : list of :class:`~pdrtpy.measurement.Measurement`
+            Input :math:`CH^{+}` measurements to be fit.
         """
         super().__init__(mol.CHplus(), measurements)

--- a/pdrtpy/tool/fitmap.py
+++ b/pdrtpy/tool/fitmap.py
@@ -6,10 +6,12 @@ class FitMap(NDData):
     def __init__(self, data, *args, **kwargs):
         """A class that can store fit objects in a data array but has all the nice WCS properties of NDData.
 
-        :param data: the data set, an array of lmfit.model.ModelResult or lmfit.minimizer.MinimizerResult
-        :type data: :class:`numpy.ndarray`-like
-        :param name: an identifying name for this object
-        :type name: str
+        Parameters
+        ----------
+        data : array-like
+            The data set, an array of `lmfit.model.ModelResult` or `lmfit.minimizer.MinimizerResult`.
+        name : str, optional
+            An identifying name for this object.
         """
         debug = kwargs.pop("debug", False)
         if debug:
@@ -27,8 +29,11 @@ class FitMap(NDData):
 
     @property
     def name(self):
-        """The name of this FitMap
-        :rtype: str
+        """The name of this FitMap.
+
+        Returns
+        -------
+        str
         """
         return self._name
 
@@ -39,13 +44,16 @@ class FitMap(NDData):
     def get_pixel(self, world_x, world_y):
         # @TODO: allow non-rounding. param round=T/F
         # @TODO: move to util? this method is copied from measurement.py
-        """Return the nearest pixel coordinates to the input world coordinates x,y
-        The pixel values will be rounded to the nearest integer
+        """Return the nearest pixel coordinates to the input world coordinates x,y.
 
-        :param world_x: The horizontal world coordinate
-        :type world_x: float
-        :param world_y: The vertical world coordinate
-        :type world_y: float
+        The pixel values will be rounded to the nearest integer.
+
+        Parameters
+        ----------
+        world_x : float
+            The horizontal world coordinate.
+        world_y : float
+            The vertical world coordinate.
         """
         if self.wcs is None:
             raise Exception(f"No wcs in this FitMap {self.name}")
@@ -53,33 +61,40 @@ class FitMap(NDData):
 
     def get_pixel_from_coord(self, coord):
         """Return the nearest pixel coordinates to the input world coordinates.
-        The pixel values will be rounded to the nearest integer
 
-        :param coord: The world coordinate
-        :type coord: :class:~astropy.coordinates.SkyCoord`
+        The pixel values will be rounded to the nearest integer.
+
+        Parameters
+        ----------
+        coord : :class:`~astropy.coordinates.SkyCoord`
+            The world coordinate.
         """
         if self.wcs is None:
             raise Exception(f"No wcs in this FitMap {self.name}")
         return tuple(np.round(self.wcs.world_to_pixel_values(coord)).astype(int))
 
     def get_world(self, x, y):
-        """Return the world coordinates corresponding to the input pixel coordinates
+        """Return the world coordinates corresponding to the input pixel coordinates.
 
-        :param x: The horizontal pixel coordinate
-        :type x: float
-        :param y: The vertical pixel coordinate
-        :type y: float
+        Parameters
+        ----------
+        x : float
+            The horizontal pixel coordinate.
+        y : float
+            The vertical pixel coordinate.
         """
         if self.wcs is None:
             raise Exception(f"No wcs in this FitMap {self.name}")
         return tuple(self.wcs.pixel_to_world_values([[x, y]])[0])
 
     def get_skycoord(self, x, y):
-        """Return the Sky Coordinate corresponding to the input pixel coordinates
+        """Return the Sky Coordinate corresponding to the input pixel coordinates.
 
-        :param x: The horizontal pixel coordinate
-        :type x: float
-        :param y: The vertical pixel coordinate
-        :type y: float
+        Parameters
+        ----------
+        x : float
+            The horizontal pixel coordinate.
+        y : float
+            The vertical pixel coordinate.
         """
         return self.wcs.pixel_to_world([x], [y])

--- a/pdrtpy/tool/lineratiofit.py
+++ b/pdrtpy/tool/lineratiofit.py
@@ -108,18 +108,23 @@ class _PixelResult:
 
 
 class LineRatioFit(ToolBase):
-    """LineRatioFit is a tool to fit observations of intensity ratios to a set of PDR models. It takes as input a set of observations with errors represented as :class:`~pdrtpy.measurement.Measurement` and  :class:`~pdrtpy.modelset.ModelSet` for the models to which the data will be fitted. The observations should be spectral line or continuum intensities.  They can be spatial maps or single pixel values. They should have the same spatial resolution.
+    """Tool to fit observations of intensity ratios to a set of PDR models.
 
-    The models to be fit are stored as intensity ratios. The input observations will be use to create ratios that correspond to models. From there a minimization fit is done to determine the density and radiation field that best fit the data. At least 3 observations are needed in order to make at least 2 ratios. With fewer ratios, no fitting can be done. More ratios generally means better determined density and radiation field, assuming the data are consistent with each other.
+    Takes as input a set of observations with errors represented as
+    :class:`~pdrtpy.measurement.Measurement` and a
+    :class:`~pdrtpy.modelset.ModelSet` for the models to fit. Observations
+    should be spectral line or continuum intensities, either spatial maps or
+    single pixel values at the same spatial resolution.
 
-    Once the fit is done, :class:`~pdrtpy.plot.LineRatioPlot` can be used to view the results.
+    At least 3 observations are needed to make at least 2 ratios. Once the
+    fit is done, :class:`~pdrtpy.plot.LineRatioPlot` can be used to view the results.
 
-
-    :param modelset: The set of PDR models to use for fitting.
-    :type modelset: :class:`~pdrtpy.modelset.ModelSet`
-
-    :param measurements: Input measurements to be fit.
-    :type measurements: list or dict of :class:`~pdrtpy.measurement.Measurement`. If dict, the keys should be the Measurement *identifiers*.
+    Parameters
+    ----------
+    modelset : :class:`~pdrtpy.modelset.ModelSet`
+        The set of PDR models to use for fitting.
+    measurements : list or dict of :class:`~pdrtpy.measurement.Measurement`, optional
+        Input measurements to be fit. If dict, keys should be Measurement identifiers.
     """
 
     def __init__(self, modelset, measurements=None):
@@ -151,9 +156,11 @@ class LineRatioFit(ToolBase):
 
     @property
     def fit_result(self):
-        """The result of the fitting procedure which includes fit statistics, variable values and uncertainties, and correlations between variables.  For each pixel, there will be one instance of :class:`lmfit.minimizer.MinimizerResult`.
+        """The result of the fitting procedure, including fit statistics, variable values and uncertainties, and correlations. One :class:`lmfit.minimizer.MinimizerResult` per pixel.
 
-        :rtype:  :class:`~pdrtpy.tool.FitMap`
+        Returns
+        -------
+        :class:`~pdrtpy.tool.FitMap`
         """
         return self._fitresult
 
@@ -164,9 +171,11 @@ class LineRatioFit(ToolBase):
 
     @property
     def measurements(self):
-        """The stored :class:`measurements <pdrtpy.measurement.Measurement>` as a dictionary with Measurement IDs as keys
+        """The stored measurements as a dictionary with Measurement IDs as keys.
 
-        :rtype: dict of :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        dict of :class:`~pdrtpy.measurement.Measurement`
         """
         return self._measurements
 
@@ -174,7 +183,9 @@ class LineRatioFit(ToolBase):
     def measurementIDs(self):
         """The stored measurement IDs, which are strings.
 
-        :rtype: :class:`dict_keys`
+        Returns
+        -------
+        :class:`dict_keys`
         """
 
         if self._measurements is None:
@@ -185,15 +196,19 @@ class LineRatioFit(ToolBase):
     def observed_ratios(self):
         """The list of the observed line ratios that have been input so far.
 
-        :rtype: list of str
+        Returns
+        -------
+        list of str
         """
         return list(self._observedratios.keys())
 
     @property
     def ratiocount(self):
-        """The number of ratios that match models available in the current :class:`~pdrtpy.modelset.ModelSet` given the current set of measurements
+        """The number of ratios that match models available in the current :class:`~pdrtpy.modelset.ModelSet` given the current set of measurements.
 
-        :rtype: int
+        Returns
+        -------
+        int
         """
         # call to  modelset._get_ratio_MA 01938elements is expensive. So set it once for each run.
         if self._ratiocount is None:
@@ -204,7 +219,9 @@ class LineRatioFit(ToolBase):
     def density(self):
         """The computed hydrogen nucleus density value(s).
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._density
 
@@ -212,17 +229,26 @@ class LineRatioFit(ToolBase):
     def radiation_field(self):
         """The computed radiation field value(s).
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         return self._radiation_field
 
     def chisq(self, min=False):
         r"""The computed chisquare value(s).
 
-        :type min: bool
-        :param min: If `True` return the minimum reduced :math:`\chi^2`.  In the case of map inputs this will be a spatial map of mininum :math:`\chi^2`.  If `False` with map inputs the entire :math:`\chi^2` hypercube is returned.  If `True` with single pixel inputs, a single value is returned.  If `False` with single pixel inputs, :math:`\chi^2` as a function of density and radiation field is returned.
+        Parameters
+        ----------
+        min : bool, optional
+            If True, return the minimum :math:`\chi^2`. For map inputs, returns a
+            spatial map of the minimum; for single-pixel inputs, returns a scalar.
+            If False, returns the full :math:`\chi^2` as a function of density and
+            radiation field. Default: False.
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         if min:
             return self._chisq_min
@@ -232,10 +258,17 @@ class LineRatioFit(ToolBase):
     def reduced_chisq(self, min=False):
         r"""The computed reduced chisquare value(s).
 
-        :type min: bool
-        :param min: If `True` return the minimum reduced :math:`\chi_\nu^2`.  In the case of map inputs this will be a spatial map of mininum :math:`\chi_\nu^2`.  If `False` with map inputs the entire :math:`\chi_\nu^2` hypercube is returned.  If `True` with single pixel inputs, a single value is returned.  If `False` with single pixel inputs, :math:`\chi_\nu^2` as a function of density and radiation field is returned.
+        Parameters
+        ----------
+        min : bool, optional
+            If True, return the minimum :math:`\chi_\nu^2`. For map inputs, returns
+            a spatial map of the minimum; for single-pixel inputs, returns a scalar.
+            If False, returns the full :math:`\chi_\nu^2` as a function of density and
+            radiation field. Default: False.
 
-        :rtype: :class:`~pdrtpy.measurement.Measurement`
+        Returns
+        -------
+        :class:`~pdrtpy.measurement.Measurement`
         """
         if min:
             return self._reduced_chisq_min
@@ -243,10 +276,12 @@ class LineRatioFit(ToolBase):
             return self._reduced_chisq
 
     def _init_measurements(self, m):
-        """Initialize the measurements from an input list or dict. If a dict, the dictionary keys must be valid measurement identifiers.
+        """Initialize the measurements from an input list or dict.
 
-        :param m: the input list of Measurements
-        :type m: list, tuple, or dict
+        Parameters
+        ----------
+        m : list, tuple, or dict
+            The input Measurements. If dict, keys must be valid measurement identifiers.
         """
         self._masks = dict()  # need to save these so they can be reset later
         if m is None:
@@ -276,13 +311,16 @@ class LineRatioFit(ToolBase):
         return np.all([m.shape == s1 for m in d.values()])
 
     def _check_header(self, kw, value=NotImplemented):
-        """Check to see if any of the given keyword values differ for
-        the input measurements.
+        """Check to see if any of the given keyword values differ for the input measurements.
 
-        :param kw: the keyword to check
-        :type kw: str
-        :param value: If given and not NotImplemented, then check that all *kw* values of the input measurements requal this value.  The default is the special value NotImplemented rather than None which allows us to check against None if needed.
-        :type kw: any
+        Parameters
+        ----------
+        kw : str
+            The keyword to check.
+        value : any, optional
+            If given and not ``NotImplemented``, check that all *kw* values equal this.
+            The default is ``NotImplemented`` (not ``None``) so that ``None`` can be
+            checked against explicitly.
         """
         d = self._measurements
         fk = utils.firstkey(d)
@@ -322,11 +360,14 @@ class LineRatioFit(ToolBase):
         return self._check_shapes(self._modelratios)
 
     def add_measurement(self, m):
-        r"""Add a Measurement to internal dictionary used to compute ratios. This measurement may be intensity units (erg :math:`{\rm s}^{-1}` :math:`{\rm cm}^{-2}`) or integrated intensity (K km/s).
+        r"""Add a Measurement to the internal dictionary used to compute ratios.
 
-        :param m: a Measurement instance to be added to this tool
-        :type m: :class:`~pdrtpy.measurement.Measurement`.
+        The measurement may be in intensity units (:math:`{\rm erg~s}^{-1}` :math:`{\rm cm}^{-2}`) or integrated intensity (K km/s).
 
+        Parameters
+        ----------
+        m : :class:`~pdrtpy.measurement.Measurement`
+            A Measurement instance to be added to this tool.
         """
         if self._measurements:
             self._measurements[m.id] = m
@@ -337,22 +378,28 @@ class LineRatioFit(ToolBase):
     def remove_measurement(self, id):
         """Delete a measurement from the internal dictionary used to compute ratios.
 
-        :param id: the measurement identifier
-        :type id: str
-        :raises KeyError: if id not in existing Measurements
+        Parameters
+        ----------
+        id : str
+            The measurement identifier.
+
+        Raises
+        ------
+        KeyError
+            If id not in existing Measurements.
         """
         del self._measurements[id]
         self._set_model_files_used()
 
     def read_models(self, unit=u.dimensionless_unscaled):
-        """Given a list of measurement IDs, find and open the FITS files that have matching ratios
-        and populate the _modelratios dictionary.  Uses :class:`pdrtpy.measurement.Measurement` as
-        a storage mechanism.
+        """Given a list of measurement IDs, find and open the FITS files with matching ratios and populate ``_modelratios``.
 
-           :param  m: list of measurement IDS (string)
-           :type m: list
-           :param unit: units of the data
-           :type unit: string or astropy.Unit
+        Uses :class:`pdrtpy.measurement.Measurement` as a storage mechanism.
+
+        Parameters
+        ----------
+        unit : str or :class:`astropy.units.Unit`, optional
+            Units of the data.
         """
         self._modelratios = self._modelset.get_models(self.measurementIDs, model_type="ratio")
         if self.ratiocount < 2:
@@ -389,9 +436,12 @@ class LineRatioFit(ToolBase):
             utils._trim_all_to_H2(self._modelratios)
 
     def _check_compatibility(self):
-        """Check that all Measurements are compatible (beams, coordinate systems, shapes) so that the computation make commence.
+        """Check that all Measurements are compatible (beams, coordinate systems, shapes) so that the computation can commence.
 
-        :raises Exception: if headers and shapes don't match, warns if no beam present
+        Raises
+        ------
+        Exception
+            If headers and shapes don't match; warns if no beam present.
         """
 
         if not self._check_measurement_shapes():
@@ -436,56 +486,46 @@ class LineRatioFit(ToolBase):
         # if not self._check_header("BUNIT") ...
 
     def run(self, **kwargs):
-        """Run the full computation using all the :class:`observations <pdrtpy.measurement.Measurement>` added.   This will
-        check compatibility of input observations (e.g., beam parameters, coordinate types, axes lengths) and
-        raise exceptions if the observations don't match each other.
+        """Run the full computation using all the added observations.
 
-           :param mask: Indicate how to mask image observations (Measurements) before computing the density
-                        and radiation field. Possible values are:
+        Checks compatibility of input observations (beam parameters, coordinate
+        types, axes lengths) and raises exceptions if they don’t match.
 
-             ['mad', multiplier]   - compute standard deviation using median absolute deviation (astropy.mad_std),
-                                     and mask out values between +/- multiplier*mad_std.  Example: ['mad',1.0]
+        Parameters
+        ----------
+        mask : list or None, optional
+            Indicate how to mask image observations before computing density and
+            radiation field. Possible values:
 
-             ['data', (low,high)]  - mask based on data values, mask out data between low and high
+            - ``[‘mad’, multiplier]`` — mask values between +/- multiplier*mad_std
+            - ``[‘data’, (low, high)]`` — mask data values between low and high
+            - ``[‘clip’, (low, high)]`` — mask data values outside [low, high]
+            - ``[‘error’, (low, high)]`` — mask where error pixel is below low or above high
+            - ``None`` — no masking (default)
 
-             ['clip', (low,high)]  - mask based on data values, mask out data below low and above high
+        method : str, optional
+            Fitting method. Default: ``’leastsq’`` (Levenberg-Marquardt). See
+            https://lmfit-py.readthedocs.io/en/latest/fitting.html#fit-methods-table.
+        nan_policy : str, optional
+            Action if fit returns NaN. One of ``’raise’`` (default), ``’propagate’``, ``’omit’``.
+        workers : int or None, optional
+            Worker processes for parallel pixel fitting. ``None`` uses serial fitting.
+            ``-1`` uses all CPUs. Ignored for single-pixel fits, emcee, and when
+            ``joint_fit`` is not None. Default: None.
+        joint_fit : str or None, optional
+            Controls joint pixel fitting:
 
-             ['error', (low,high)] - mask based on uncertainty plane, mask out data where the corresponding error pixel value
-                                     is below low or above high
+            - ``None`` (default): serial or parallel per-pixel fitting.
+            - ``’hybrid’``: joint scipy fit + single-pixel re-fits for boundary pixels. ~3× faster than ``workers=-1``.
+            - ``’fast’``: joint scipy fit only, no post-processing. ~11× faster but ~7–9% accuracy loss near boundaries.
 
-                              None - Don't mask data. This is the default.
+            All joint-fit modes use TRF. Ignored for single-pixel fits and emcee.
 
-           :type mask:  list or None
-           :param method: the fitting method to be used. The default is 'leastsq', which is Levenberg-Marquardt least squares.  For other options see https://lmfit-py.readthedocs.io/en/latest/fitting.html#fit-methods-table
-           :type method: str
-           :param nan_policy: Specifies action if fit returns NaN values. One of:
-                * ’raise’ : a ValueError is raised [Default]
-                * ’propagate’ : the values returned from userfcn are un-altered
-                * ’omit’ : non-finite values are filtered
-           :type nan_policy: str
-           :param workers: Number of worker processes for parallel pixel fitting.
-                           ``None`` (default) uses serial fitting. ``-1`` uses all available
-                           CPUs. A positive integer sets the exact number of workers.
-                           Ignored for single-pixel fits, emcee, and when ``joint_fit`` is not ``None``.
-           :type workers: int or None
-           :param joint_fit: Controls joint pixel fitting.
-
-                * ``None`` (default): serial or parallel per-pixel fitting.
-                * ``'hybrid'``: joint scipy fit for all pixels simultaneously using a
-                  block-diagonal Jacobian sparsity pattern, followed by single-pixel
-                  re-fits for any pixels that did not move from their coarse initial
-                  guess (typically ~10% of pixels that start at model boundaries).
-                  Accurate and ~3× faster than ``workers=-1``.
-                * ``'fast'``: joint scipy fit only, no post-processing.  ~11× faster
-                  than serial but may have ~7–9% typical accuracy loss for pixels
-                  near model boundaries.  Suitable for quick exploration.
-
-                All joint-fit modes force trust-region reflective (TRF) and are
-                ignored for single-pixel fits and emcee.
-           :type joint_fit: str or None
-
-           :raises Exception: if no models match the input observations, observations are not compatible,
-                              or on unrecognized parameters, or NaN encountered.
+        Raises
+        ------
+        Exception
+            If no models match the input observations, observations are incompatible,
+            parameters are unrecognized, or NaN is encountered.
         """
         # @todo global masking for 'data', 'clip', 'error' not entirely useful unless all data/error have same ranges.
         # need something like ['data',['key1':(low,hi), 'key2',(low,hi),...], which is very complicated.
@@ -554,10 +594,14 @@ class LineRatioFit(ToolBase):
             self._measurements[m].mask = deepcopy(self._masks[m])
 
     def _mask_measurements(self, mask):
-        """Set the mask on the measurements based on noise characteristics.  This is so that
-         we don't compute garbage n,G0 where observed ratios are noise divided by noise.
+        """Set the mask on the measurements based on noise characteristics.
 
-        :param mask: Indicate how to mask image observations before computing the density and radiation field. See run()>
+        Prevents computing garbage n,G0 where observed ratios are noise / noise.
+
+        Parameters
+        ----------
+        mask : list or None
+            Indicate how to mask image observations. See :meth:`run` for valid values.
         """
         if mask is None:
             return
@@ -752,12 +796,14 @@ class LineRatioFit(ToolBase):
         self._makehistory(self._reduced_chisq)
 
     def write_chisq(self, chi="chisq.fits", rchi="rchisq.fits", overwrite=True):
-        """Write the chisq and reduced-chisq data to a file
+        """Write the chisq and reduced-chisq data to a file.
 
-        :param chi: FITS file to write the chisq map to.
-        :type  chi: str
-        :param rchi: FITS file to write the reduced chisq map to.
-        :type rchi: str
+        Parameters
+        ----------
+        chi : str, optional
+            FITS file to write the chisq map to. Default: ``"chisq.fits"``.
+        rchi : str, optional
+            FITS file to write the reduced chisq map to. Default: ``"rchisq.fits"``.
         """
         self._chisq.write(chi, overwrite=overwrite, hdu_mask="MASK", output_verify="silentfix")
         self._reduced_chisq.write(rchi, overwrite=overwrite, hdu_mask="MASK", output_verify="silentfix")
@@ -1240,10 +1286,12 @@ class LineRatioFit(ToolBase):
         self._makehistory(self._chisq_min)
 
     def _makehistory(self, image):
-        """Add information to HISTORY keyword indicating how the density and radiation field were computed (measurements given, ratios used)
+        """Add HISTORY keyword indicating how density and radiation field were computed.
 
-        :param image: The image which to add the history to.
-        :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+            The image to which to add the history.
         """
         s = "Measurements provided: " + str(list(self._measurements.keys()))
         utils.history(s, image)
@@ -1253,24 +1301,28 @@ class LineRatioFit(ToolBase):
         utils.dataminmax(image)
 
     def _ratioHeader(self, numerator, denominator, label):
-        """Add the RATIO identifier to the appropriate image
+        """Add the RATIO identifier to the appropriate image.
 
-        :param numerator:  numerator key of the line ratio
-        :type numerator: str
-        :param denominator:  denominator key of the line ratio
-        :type denominator: str
-        :param label:  ratio key indicating which observation image (Measuremnet) to use
-        :type label: str
+        Parameters
+        ----------
+        numerator : str
+            Numerator key of the line ratio.
+        denominator : str
+            Denominator key of the line ratio.
+        label : str
+            Ratio key indicating which observation image (Measurement) to use.
         """
         utils.addkey("RATIO", label, self._observedratios[label])
         utils.dataminmax(self._observedratios[label])
         utils.signature(self._observedratios[label])
 
     def _fixheader(self, image):
-        """Put additional axis and header values into an image
+        """Put additional axis and header values into an image.
 
-        :param image: The image to which to add the header values
-        :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+        Parameters
+        ----------
+        image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+            The image to which to add the header values.
         """
         if self._modelnaxis == 2:
             naxis = len(image.shape)
@@ -1318,9 +1370,11 @@ class LineRatioFit(ToolBase):
     @property
     def table(self):
         # @TODO: make this work for map data ?
-        r"""Construct the table of input Measurements, and if the fit has been run, the density, radiation field, and :math:`\chi^2` values
+        r"""Construct the table of input Measurements and, if the fit has been run, the density, radiation field, and :math:`\chi^2` values.
 
-        :rtype: :class:`astropy.table.Table`
+        Returns
+        -------
+        :class:`astropy.table.Table`
         """
         v = self._measurements.values()
         # This only works for astropy version >= 4.1

--- a/pdrtpy/tool/toolbase.py
+++ b/pdrtpy/tool/toolbase.py
@@ -4,9 +4,11 @@ import pdrtpy.utils as utils
 
 
 class ToolBase(ABC):
-    """Base class object for PDR Toolbox tools.  This class implements a simple
-    interface with a run method.  Tools will generally do some set up
-    such as reading in observational data before run() can be invoked.
+    """Base class object for PDR Toolbox tools.
+
+    This class implements a simple interface with a run method. Tools will
+    generally do some set up such as reading in observational data before
+    ``run()`` can be invoked.
     """
 
     def __init__(self):
@@ -27,21 +29,23 @@ class ToolBase(ABC):
 
     @property
     def has_maps(self):
-        """Are the Measurements used map-based?. (i.e., have 2 spatial axes)
+        """Are the Measurements used map-based? (i.e., have 2 spatial axes)
 
-        :returns: True, if the observational inputs are spatial maps, False otherwise
-
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if the observational inputs are spatial maps, False otherwise.
         """
-
         return self._measurementnaxis > 1
 
     @property
     def has_vectors(self):
         """Are the Measurements used a Nx1 vector, e.g. read in from a table with :meth:`~pdrtpy.Measurement.from_table`.
 
-        :returns: True, if the observational inputs are a vector, False otherwise
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if the observational inputs are a vector, False otherwise.
         """
         fk = utils.firstkey(self._measurements)
         return self._measurementnaxis == 1 and self._measurements[fk].data.size > 1
@@ -51,7 +55,9 @@ class ToolBase(ABC):
     def has_scalar(self):
         """Are the Measurements used scalars.
 
-        :returns: True, if the observational inputs are scalars, False otherwise
-        :rtype: bool
+        Returns
+        -------
+        bool
+            True if the observational inputs are scalars, False otherwise.
         """
         return self._measurementnaxis == 0

--- a/pdrtpy/utils/fits.py
+++ b/pdrtpy/utils/fits.py
@@ -9,14 +9,16 @@ from pdrtpy.utils.paths import now
 
 
 def addkey(key, value, image):
-    """Add a (FITS) keyword,value pair to the image header
+    """Add a (FITS) keyword,value pair to the image header.
 
-    :param key:   The keyword to add to the header
-    :type key:    str
-    :param value: the value for the keyword
-    :type value:  any native type
-    :param image: The image which to add the key,val to.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    key : str
+        The keyword to add to the header.
+    value : any
+        The value for the keyword.
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the key,val.
     """
     if key in image.header and isinstance(value, str):
         s = str(image.header[key])
@@ -28,12 +30,14 @@ def addkey(key, value, image):
 
 
 def comment(value, image):
-    """Add a comment to an image header
+    """Add a comment to an image header.
 
-    :param value: the value for the comment
-    :type value:  str
-    :param image: The image which to add the comment to
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    value : str
+        The value for the comment.
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the comment.
     """
     # direct assignment will always make a new card for COMMENT
     # See https://docs.astropy.org/en/stable/io/fits/
@@ -41,55 +45,66 @@ def comment(value, image):
 
 
 def history(value, image):
-    """Add a history record to an image header
+    """Add a history record to an image header.
 
-    :param value: the value for the history record
-    :type value:  str
-    :param image: The image which to add the HISTORY to
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    value : str
+        The value for the history record.
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the HISTORY.
     """
     # direct assignment will always make a new card for HISTORY
     image.header["HISTORY"] = value
 
 
 def setkey(key, value, image):
-    """Set the value of an existing keyword in the image header
+    """Set the value of an existing keyword in the image header.
 
-    :param key:   The keyword to set in the header
-    :type key:    str
-    :param value: the value for the keyword
-    :type value:  any native type
-    :param image: The image which to add the key,val to.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    key : str
+        The keyword to set in the header.
+    value : any
+        The value for the keyword.
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the key,val.
     """
     image.header[key] = value
 
 
 def dataminmax(image):
-    """Set the data maximum and minimum in image header
+    """Set the data maximum and minimum in image header.
 
-    :param image: The image which to add the key,val to.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the key,val.
     """
     setkey("DATAMIN", np.nanmin(image.data), image)
     setkey("DATAMAX", np.nanmax(image.data), image)
 
 
 def signature(image):
-    """Add AUTHOR and DATE keywords to the image header
-    Author is 'PDR Toolbox', date as returned by now()
+    """Add AUTHOR and DATE keywords to the image header.
 
-    :param image: The image which to add the key,val to.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Author is ``'PDR Toolbox'``, date as returned by :func:`~pdrtpy.utils.paths.now`.
+
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to which to add the key,val.
     """
     setkey("AUTHOR", "PDR Toolbox " + version(), image)
     setkey("DATE", now(), image)
 
 
 def firstkey(d):
-    """Return the "first" key in a dictionary
+    """Return the "first" key in a dictionary.
 
-    :param d: the dictionary
-    :type d: dict
+    Parameters
+    ----------
+    d : dict
+        The dictionary.
     """
     return next(iter(d))

--- a/pdrtpy/utils/helpers.py
+++ b/pdrtpy/utils/helpers.py
@@ -9,22 +9,36 @@ from pdrtpy.utils.fits import comment
 
 
 def warn(cls, msg):
-    """Issue a warning
+    """Issue a warning.
 
-    :param cls:  The calling Class
-    :type cls: Class
-    :param msg:  The warning message
-    :type msg: str
+    Parameters
+    ----------
+    cls : class
+        The calling class.
+    msg : str
+        The warning message.
     """
     # use stacklevel=3 so we get a reference to the caller of warn().
     warnings.warn(cls.__class__.__name__ + ": " + msg, stacklevel=3)
 
 
 def is_image(image):
-    """Check if a Measurement is an image. The be an image it must have a header with axes keywords and a WCS to be considered an image.  This is to distiguish Measurements that have a data array with more than one member from a true image.
-    :param image: the image to check. It must have a :class:`numpy.ndarray` data member and :class:`astropy.units.Unit` unit member or a header BUNIT keyword.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: True if it is an image, False otherwise.
+    """Check if a Measurement is an image.
+
+    To be an image it must have a header with axes keywords and a WCS.
+    This is to distinguish Measurements that have a data array with more
+    than one member from a true image.
+
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to check. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member or a header BUNIT keyword.
+
+    Returns
+    -------
+    bool
+        True if it is an image, False otherwise.
     """
     if getattr(image, "header", None) is None or getattr(image, "wcs", None) is None:
         return False
@@ -38,9 +52,11 @@ def is_image(image):
 
 
 def is_ratio(identifier):
-    """Is the identifier a ratio (as opposed to an intensity)
+    """Is the identifier a ratio (as opposed to an intensity).
 
-    :rtype: bool
+    Returns
+    -------
+    bool
     """
     # find() returns -1 if char not found.
     # in our case, also rule out that the / is in the zeroth position.
@@ -48,23 +64,33 @@ def is_ratio(identifier):
 
 
 def is_even(number):
-    """Check if number is even
+    """Check if number is even.
 
-    :param number: a number
-    :return: True if even, False otherwise
-    :type number: float
-    :rtype: bool
+    Parameters
+    ----------
+    number : float
+        A number.
+
+    Returns
+    -------
+    bool
+        True if even, False otherwise.
     """
     return abs(number) % 2 == 0
 
 
 def is_odd(number):
-    """Check if number is odd
+    """Check if number is odd.
 
-    :param number: a number
-    :type number: float
-    :return: True if odd, False otherwise
-    :rtype: bool
+    Parameters
+    ----------
+    number : float
+        A number.
+
+    Returns
+    -------
+    bool
+        True if odd, False otherwise.
     """
     return not is_even(number)
 
@@ -79,12 +105,17 @@ def _has_H2(ids):
 
 def _trim_to_H2(image):
     """H2 models in wk2006 are a smaller grid 17x17 vs 25x29. So when performing operations
-    involving other models, we have to trim the other models to 17x17;  log(n,G0) from 1 to 5
+    involving other models, we have to trim the other models to 17x17;  log(n,G0) from 1 to 5.
 
-    :param image: the model to trim
-    :type image: :class:`~pdrtpy.measurement.Measurement`
-    :returns: the trimmed model
-    :rtype: :class:`~pdrtpy.measurement.Measurement`
+    Parameters
+    ----------
+    image : :class:`~pdrtpy.measurement.Measurement`
+        The model to trim.
+
+    Returns
+    -------
+    :class:`~pdrtpy.measurement.Measurement`
+        The trimmed model.
     """
     f = deepcopy(image)
     # Slice the WCS. Note this is in numpy array order, not WCS axis order
@@ -98,10 +129,12 @@ def _trim_to_H2(image):
 
 def _trim_all_to_H2(models):
     """H2 models in wk2006 are a smaller grid 17x17 vs 25x29. So when performing operations
-    involving other models, we have to trim the other models to 17x17;  log(n,G0) from 1 to 5
+    involving other models, we have to trim the other models to 17x17;  log(n,G0) from 1 to 5.
 
-    :param models: models to trim
-    :type models: :list or dict of class:`~pdrtpy.measurement.Measurement`
+    Parameters
+    ----------
+    models : list or dict of :class:`~pdrtpy.measurement.Measurement`
+        Models to trim.
     """
     if type(models) is dict:
         for id in models:

--- a/pdrtpy/utils/paths.py
+++ b/pdrtpy/utils/paths.py
@@ -10,33 +10,42 @@ from astropy.table import Table
 
 
 def now():
-    """
-    :returns: a string representing the current date and time in ISO format
+    """Return a string representing the current date and time in ISO format.
+
+    Returns
+    -------
+    str
     """
     return datetime.datetime.now().isoformat()
 
 
 def root_dir():
-    """Project root directory, including trailing slash
+    """Project root directory, including trailing slash.
 
-    :rtype: str
+    Returns
+    -------
+    str
     """
     return str(root_path()) + "/"
 
 
 def root_path():
-    """Project root directory as path
+    """Project root directory as path.
 
-    :rtype: :py:mod:`Path`
+    Returns
+    -------
+    :py:class:`pathlib.Path`
     """
     # This file lives at pdrtpy/utils/paths.py; parent.parent is pdrtpy/
     return Path(__file__).parent.parent
 
 
 def testdata_dir():
-    """Project test data directory, including trailing slash
+    """Project test data directory, including trailing slash.
 
-    :rtype: str
+    Returns
+    -------
+    str
     """
     return os.path.join(root_dir(), "testdata/")
 
@@ -44,24 +53,30 @@ def testdata_dir():
 def get_testdata(filename):
     """Get fully qualified pathname to FITS test data file.
 
-    :param filename: input filename, no path
-    :type filename: str
+    Parameters
+    ----------
+    filename : str
+        Input filename, no path.
     """
     return testdata_dir() + filename
 
 
 def model_dir():
-    """Project model directory, including trailing slash
+    """Project model directory, including trailing slash.
 
-    :rtype: str
+    Returns
+    -------
+    str
     """
     return os.path.join(root_dir(), "models/")
 
 
 def table_dir():
-    """Project ancillary tables directory, including trailing slash
+    """Project ancillary tables directory, including trailing slash.
 
-    :rtype: str
+    Returns
+    -------
+    str
     """
     return os.path.join(root_dir(), "tables/")
 
@@ -69,9 +84,14 @@ def table_dir():
 def _tablename(filename):
     """Return fully qualified path of the input table.
 
-    :param filename: input table file name
-    :type filename: str
-    :rtype: str
+    Parameters
+    ----------
+    filename : str
+        Input table file name.
+
+    Returns
+    -------
+    str
     """
     return table_dir() + filename
 
@@ -79,16 +99,21 @@ def _tablename(filename):
 def get_table(filename, format="ipac", path=None, **kwargs):
     """Return an astropy Table read from the input filename.
 
-    :param filename: input filename, no path
-    :type filename: str
-    :param format:  file format, Default: "ipac"
-    :type format: str
-    :param  path: path to filename relative to models directory.  Default of None means look in "tables" directory
-    :type path: str
-    :param kwargs: additional arguments to pass to Table.read, e.g. `header_start`, `data_start`
-    :type kwargs: dict
-    :rtype: :class:`astropy.table.Table`
+    Parameters
+    ----------
+    filename : str
+        Input filename, no path.
+    format : str, optional
+        File format. Default: ``"ipac"``.
+    path : str, optional
+        Path to filename relative to models directory. Default of None means
+        look in the ``tables`` directory.
+    **kwargs : dict
+        Additional arguments to pass to ``Table.read``, e.g. ``header_start``, ``data_start``.
 
+    Returns
+    -------
+    :class:`astropy.table.Table`
     """
     if path is None:
         return Table.read(_tablename(filename), format=format, **kwargs)

--- a/pdrtpy/utils/units.py
+++ b/pdrtpy/utils/units.py
@@ -53,12 +53,18 @@ _rad_title["Mathis"] = "FUV"
 
 def get_rad(key):
     r"""Get radiation field symbol (LaTeX) given radiation field unit.
-    If key is unrecognized, 'FUV Radiation Field' is returned.
 
-    :param key: input field unit name, e.g. 'Habing', 'Draine' or an :class:`astropy.units.Unit`
-    :returns: LaTeX string for the radiation field symbol e.g., :math:`G_0`, :math:`\chi`
-    :type key: str or :class:`astropy.units.Unit`
-    :rtype: str
+    If key is unrecognized, ``'FUV'`` is returned.
+
+    Parameters
+    ----------
+    key : str or :class:`astropy.units.Unit`
+        Input field unit name, e.g. ``'Habing'``, ``'Draine'``.
+
+    Returns
+    -------
+    str
+        LaTeX string for the radiation field symbol, e.g. :math:`G_0`, :math:`\chi`.
     """
     skey = str(key)  # in case the passed key was a Unit
     if skey in _rad_title:
@@ -70,11 +76,17 @@ def get_rad(key):
 def check_units(input_unit, compare_to):
     """Check if the input unit is equivalent to another.
 
-    :param input_unit:  the unit to check.
-    :type input_unit:  :class:`astropy.units.Unit`, :class:`astropy.units.Quantity` or str
-    :param compare_unit:  the unit to check against
-    :type compare_unit:  :class:`astropy.units.Unit`, :class:`astropy.units.Quantity` or str
-    :return: `True` if the input unit is equivalent to compare unit, `False` otherwise
+    Parameters
+    ----------
+    input_unit : :class:`astropy.units.Unit`, :class:`astropy.units.Quantity`, or str
+        The unit to check.
+    compare_to : :class:`astropy.units.Unit`, :class:`astropy.units.Quantity`, or str
+        The unit to check against.
+
+    Returns
+    -------
+    bool
+        True if the input unit is equivalent to compare unit, False otherwise.
     """
     if isinstance(input_unit, u.Unit):
         test_unit = input_unit
@@ -99,19 +111,26 @@ def is_rad(input_unit):
 
 def to(unit, image):
     r"""Convert the image values to another unit.
+
     While generally this is intended for converting radiation field
     strength maps between Habing, Draine, cgs, etc, it will work for
     any image that has a unit member variable. So, e.g., it would work
-    to convert density from :math:`{\rm cm ^{-3}}` to :math:`{\rm m^{-3}}`.
+    to convert density from :math:`{\rm cm^{-3}}` to :math:`{\rm m^{-3}}`.
     If the input image is a :class:`~pdrtpy.measurement.Measurement`, its
     uncertainty will also be converted.
 
-    :param unit: identifying the unit to convert to
-    :type unit: string or `astropy.units.Unit`
-    :param image: the image to convert. It must have a :class:`numpy.ndarray`
-        data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    unit : str or :class:`astropy.units.Unit`
+        The unit to convert to.
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     value = image.unit.to(unit)
     newmap = deepcopy(image)
@@ -130,40 +149,58 @@ def toHabing(image):
 
     between 6eV and 13.6eV (912-2066 :math:`\unicode{xC5}`).  See `Weingartner and Draine 2001, ApJS, 134, 263 <https://ui.adsabs.harvard.edu/abs/2001ApJS..134..263W/abstract>`_, section 4.1
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray`
-       data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     return to("Habing", image)
 
 
 def toDraine(image):
-    r"""Convert a radiation field strength image to Draine units (\chi).
+    r"""Convert a radiation field strength image to Draine units (:math:`\chi`).
 
     :math:`{\rm 1~Draine = 2.72\times10^{-3}~erg~s^{-1}~cm^{-2}}`
 
     between 6eV and 13.6eV (912-2066 :math:`\unicode{xC5}`).  See `Weingartner and Draine 2001, ApJS, 134, 263 <https://ui.adsabs.harvard.edu/abs/2001ApJS..134..263W/abstract>`_, section 4.1
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray`
-       data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     return to("Draine", image)
 
 
 def toMathis(image):
-    r"""Convert a radiation field strength image to Mathis units
+    r"""Convert a radiation field strength image to Mathis units.
 
     :math:`{\rm 1~Mathis = 1.81\times10^{-3}~erg~s^{-1}~cm^{-2}}`
 
     between 6eV and 13.6eV (912-2066 :math:`\unicode{xC5}`).  See `Weingartner and Draine 2001, ApJS, 134, 263 <https://ui.adsabs.harvard.edu/abs/2001ApJS..134..263W/abstract>`_, section 4.1
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray`
-       data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     return to("Mathis", image)
 
@@ -171,17 +208,27 @@ def toMathis(image):
 def tocgs(image):
     r"""Convert a radiation field strength image to :math:`{\rm erg~s^{-1}~cm^{-2}}`.
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray` data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     return to(_RFS_UNIT_, image)
 
 
 def convert_integrated_intensity(image, wavelength=None):
     r"""Convert integrated intensity from :math:`{\rm K~km~s}^{-1}` to
-    :math:`{\rm erg~s^{-1}~cm^{-2}~sr^{-1}}`, assuming
-    :math:`B_\lambda d\lambda = 2kT/\lambda^3 dV` where :math:`T dV` is the integrated intensity in K km/s and :math:`\lambda` is the wavelength.  The derivation:
+    :math:`{\rm erg~s^{-1}~cm^{-2}~sr^{-1}}`.
+
+    Assumes :math:`B_\lambda d\lambda = 2kT/\lambda^3 dV` where :math:`T dV` is
+    the integrated intensity in K km/s and :math:`\lambda` is the wavelength.
+    The derivation:
 
     .. math::
 
@@ -199,13 +246,23 @@ def convert_integrated_intensity(image, wavelength=None):
 
        B_\lambda d\lambda = 2\times10^5~kT/\lambda^3~dV,
 
-    with :math:`\lambda`  in cm, the factor :math:`10^5` is to convert :math:`dV` in :math:`{\rm km~s}^{-1}` to :math:`{\rm cm~s}^{-1}`.
+    with :math:`\lambda` in cm, the factor :math:`10^5` is to convert :math:`dV`
+    in :math:`{\rm km~s}^{-1}` to :math:`{\rm cm~s}^{-1}`.
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray` data member and :class:`astropy.units.Unit` unit member or header BUNIT keyword. It's units must be K km/s
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :param wavelength: the wavelength of the observation. The default is to determine wavelength from the image header RESTFREQ keyword
-    :type wavelength: :class:`astropy.units.Quantity`
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member,
+        :class:`astropy.units.Unit` unit member or header BUNIT keyword, and
+        units must be K km/s.
+    wavelength : :class:`astropy.units.Quantity`, optional
+        The wavelength of the observation. The default is to determine wavelength
+        from the image header RESTFREQ keyword.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     f = image.header.get("RESTFREQ", None)
     rf = getattr(image, "_restfreq", None)
@@ -235,16 +292,24 @@ def convert_integrated_intensity(image, wavelength=None):
 
 
 def convert_if_necessary(image):
-    r"""Helper method to convert integrated intensity units in an
-    image or Measurement from :math:`{\rm K~km~s}^{-1}` to :math:`{\rm
-    erg~s^{-1}~cm^{-2}~sr^{-1}}`. If a conversion is necessary, the
-    :meth:`convert_integrated_intensity` is called.  If not, the image
-    is returned unchanged.
+    r"""Convert integrated intensity units if necessary.
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray` data member and :class:`astropy.units.Unit` unit member or a header BUNIT keyword. It's units must be :math:`{\rm K~km~s}^{-1}`. It must also have a header RESTFREQ keyword.
-    :type image: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Converts from :math:`{\rm K~km~s}^{-1}` to
+    :math:`{\rm erg~s^{-1}~cm^{-2}~sr^{-1}}` by calling
+    :func:`convert_integrated_intensity`. If no conversion is necessary,
+    the image is returned unchanged.
 
-    :return: an image with converted values and units
+    Parameters
+    ----------
+    image : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member,
+        :class:`astropy.units.Unit` unit member or header BUNIT keyword with units
+        :math:`{\rm K~km~s}^{-1}`, and a header RESTFREQ keyword.
+
+    Returns
+    -------
+    :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        An image with converted values and units.
     """
     _u1 = u.Unit(image.header["BUNIT"])
     _u2 = u.Unit("K km s-1")
@@ -257,11 +322,16 @@ def convert_if_necessary(image):
 def float_formatter(quantity, precision):
     """Format a quantity as a LaTeX string with the given number of significant figures.
 
-    :param quantity: the quantity to format
-    :type quantity: :class:`astropy.units.Quantity`
-    :param precision: the number of significant figures
-    :type precision: int
-    :rtype: str
+    Parameters
+    ----------
+    quantity : :class:`astropy.units.Quantity`
+        The quantity to format.
+    precision : int
+        The number of significant figures.
+
+    Returns
+    -------
+    str
     """
     format_spec = f".{precision}g"
     number = Latex.format_exponential_notation(np.squeeze(quantity.value), format_spec=format_spec)

--- a/pdrtpy/utils/wcs.py
+++ b/pdrtpy/utils/wcs.py
@@ -9,12 +9,18 @@ from pdrtpy.utils.units import draine_unit, get_rad, habing_unit, is_rad
 
 def mask_union(arrays):
     """Return the union mask (logical OR) of the input masked arrays.
-    This is useful when doing arithmetic on images that don't have identical masks
-    and you want the most restrictive mask.
 
-    :param arrays: masked arrays to unionize
-    :type arrays: :class:`numpy.ma.masked_array`
-    :rtype: mask
+    This is useful when doing arithmetic on images that don't have identical
+    masks and you want the most restrictive mask.
+
+    Parameters
+    ----------
+    arrays : :class:`numpy.ma.masked_array`
+        Masked arrays to unionize.
+
+    Returns
+    -------
+    mask
     """
     z = list()
     for m in arrays:
@@ -23,11 +29,19 @@ def mask_union(arrays):
 
 
 def dropaxis(w):
-    """Drop the first single dimension axis from a World Coordiante System.  Returns the modified WCS if it had a single dimension axis or the original WCS if not.
+    """Drop the first single dimension axis from a World Coordinate System.
 
-    :param w: a WCS
-    :type w: :class:`astropy.wcs.WCS`
-    :rtype: :class:`astropy.wcs.WCS`
+    Returns the modified WCS if it had a single dimension axis or the
+    original WCS if not.
+
+    Parameters
+    ----------
+    w : :class:`astropy.wcs.WCS`
+        A WCS.
+
+    Returns
+    -------
+    :class:`astropy.wcs.WCS`
     """
     for i in range(len(w._naxis)):
         if w._naxis[i] == 1:
@@ -36,12 +50,17 @@ def dropaxis(w):
 
 
 def has_single_axis(w):
-    """Check if the input WCS has any single dimension axes
+    """Check if the input WCS has any single dimension axes.
 
-    :param w: a WCS
-    :type w: :class:`astropy.wcs.WCS`
-    :return: True if the input WCS has any single dimension axes, False otherwise
-    :rtype: bool
+    Parameters
+    ----------
+    w : :class:`astropy.wcs.WCS`
+        A WCS.
+
+    Returns
+    -------
+    bool
+        True if the input WCS has any single dimension axes, False otherwise.
     """
     for i in range(len(w._naxis)):
         if w._naxis[i] == 1:
@@ -52,11 +71,16 @@ def has_single_axis(w):
 def squeeze(image):
     """Remove single-dimensional entries from image data and WCS.
 
-    :param image: the image to convert. It must have a :class:`numpy.ndarray` data member and :class:`astropy.units.Unit` unit member.
-    :type image: :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
+    Parameters
+    ----------
+    image : :class:`astropy.nddata.CCDData` or :class:`~pdrtpy.measurement.Measurement`
+        The image to convert. It must have a :class:`numpy.ndarray` data member
+        and :class:`astropy.units.Unit` unit member.
 
-    :return: an image with single axes removed
-    :rtype: :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement` as input
+    Returns
+    -------
+    :class:`astropy.nddata.CCDData` or :class:`~pdrtpy.measurement.Measurement`
+        An image with single axes removed (same type as input).
     """
     while has_single_axis(image.wcs):
         image.wcs = dropaxis(image.wcs)
@@ -81,15 +105,25 @@ def squeeze(image):
 
 
 def fliplabel(label):
-    """Given a label that has a numerator and a denominator separated by a '/', return the
-    reciprocal label.  For example, if the input label is '(x+y)/z' return 'z/(x+y)'.  This
-    method simply looks for the '/' and swaps the substrings before and after it.
+    """Given a label with a numerator and denominator separated by ``'/'``, return the reciprocal label.
 
-    :param label: the label to flip
-    :type label: str
-    :return: the reciprocal label
-    :rtype: str
-    :raises ValueError: if the input label has no '/'
+    For example, if the input label is ``'(x+y)/z'`` return ``'z/(x+y)'``. This
+    method simply looks for the ``'/'`` and swaps the substrings before and after it.
+
+    Parameters
+    ----------
+    label : str
+        The label to flip.
+
+    Returns
+    -------
+    str
+        The reciprocal label.
+
+    Raises
+    ------
+    ValueError
+        If the input label has no ``'/'``.
     """
     ii = label.index("/")
     return label[ii + 1 :] + "/" + label[0:ii]
@@ -98,14 +132,20 @@ def fliplabel(label):
 def get_xy_from_wcs(data, quantity=False, linear=False):
     """Get the x,y axis vectors from the WCS of the input image.
 
-    :param data: the input image
-    :type data: :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`.
-    :param quantity: If True, return the arrays as :class:`astropy.units.Quantity`. If False, the returned arrays are :class:`numpy.ndarray`.
-    :type quantity: bool
-    :param linear: If True, returned arrays are in linear space, if False they are in log space.
-    :type linear: bool
-    :return: The axis values as arrays.  Values are center of pixel.
-    :rtype: :class:`numpy.ndarray` or :class:`astropy.units.Quantity`
+    Parameters
+    ----------
+    data : :class:`astropy.io.fits.ImageHDU`, :class:`astropy.nddata.CCDData`, or :class:`~pdrtpy.measurement.Measurement`
+        The input image.
+    quantity : bool, optional
+        If True, return the arrays as :class:`astropy.units.Quantity`.
+        If False, return :class:`numpy.ndarray`. Default: False.
+    linear : bool, optional
+        If True, returned arrays are in linear space; if False, in log space. Default: False.
+
+    Returns
+    -------
+    :class:`numpy.ndarray` or :class:`astropy.units.Quantity`
+        The axis values as arrays. Values are center of pixel.
     """
     w = data.wcs
     if w is None:
@@ -153,12 +193,23 @@ def get_xy_from_wcs(data, quantity=False, linear=False):
 def rescale_axis_units(x, from_unit, from_ctype, to_unit, loglabel=True):
     """Rescale axis units and return updated axis values and label.
 
-    :param x: axis values as a Quantity
-    :param from_unit: original unit string
-    :param from_ctype: original CTYPE string
-    :param to_unit: target unit string, or None to keep original
-    :param loglabel: if True, prefix label with 'log(...)'
-    :return: (x, xlabel) tuple
+    Parameters
+    ----------
+    x : :class:`astropy.units.Quantity`
+        Axis values.
+    from_unit : str
+        Original unit string.
+    from_ctype : str
+        Original CTYPE string.
+    to_unit : str or None
+        Target unit string, or None to keep original.
+    loglabel : bool, optional
+        If True, prefix label with ``'log(...)'``. Default: True.
+
+    Returns
+    -------
+    tuple
+        ``(x, xlabel)`` with rescaled axis values and axis label string.
     """
     import astropy.units as u
 


### PR DESCRIPTION
## Summary

- Converts all docstrings in the package from reStructuredText style (`:param`, `:type:`, `:returns:`, `:rtype:`, `:raises:`) to NumPy docstring style, as specified in CLAUDE.md and requested in issue #103
- Preserves `r"""` prefix on docstrings containing LaTeX backslash sequences (`:math:` directives) to avoid breaking escape sequences
- Fixes `.. seealso::` directives in `modelplot.py` that were not rendering — replaced with proper NumPy `See Also` sections
- Adds `autoclass_content = "both"` to `docs/source/conf.py` so that `__init__` docstrings are rendered in the HTML API docs

## Files converted

`pdrtpy/tool/fitmap.py`, `pdrtpy/utils/helpers.py`, `pdrtpy/utils/paths.py`, `pdrtpy/utils/fits.py`, `pdrtpy/utils/wcs.py`, `pdrtpy/utils/units.py`, `pdrtpy/tool/toolbase.py`, `pdrtpy/plot/plotbase.py`, `pdrtpy/plot/lineratioplot.py`, `pdrtpy/plot/modelplot.py`, `pdrtpy/plot/excitationplot.py`, `pdrtpy/measurement.py`, `pdrtpy/modelset.py`, `pdrtpy/tool/lineratiofit.py`, `pdrtpy/tool/excitation.py`

## Test plan

- [x] `uv run sphinx-build docs/source docs/build -b html` — builds with no warnings
- [x] `uv run pytest -n auto` — 317 passed, 0 failures

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)