### PR TITLE
Add phase-space limits to LineRatioFit.run (issue #236)

### DIFF
--- a/pdrtpy/tool/lineratiofit.py
+++ b/pdrtpy/tool/lineratiofit.py
@@ -153,6 +153,10 @@ class LineRatioFit(ToolBase):
         self._minimizer = None
         self._deltasq = None
         self._ratiocount = None
+        # phase-space limits (issue #236): (lower, upper) in linear model units,
+        # populated by _normalize_phase_space_limits. Default None = unrestricted.
+        self._density_range = None
+        self._radiation_field_range = None
 
     @property
     def fit_result(self):
@@ -435,6 +439,99 @@ class LineRatioFit(ToolBase):
             warnings.warn("Trimming all model grids to match H2 grid: log(n) = 1-5, log(G0) = 1-5", stacklevel=2)
             utils._trim_all_to_H2(self._modelratios)
 
+    def _normalize_phase_space_limits(self, radiation_field_range, density_range):
+        """Normalize and validate user-supplied phase-space limits (issue #236).
+
+        Converts ``radiation_field_range`` and ``density_range`` into
+        ``(lower, upper)`` tuples of plain floats in the model's linear axis
+        units, substituting the model grid extremes for any ``None`` bound.
+        Results are stored in :attr:`_radiation_field_range` and
+        :attr:`_density_range` for use by the coarse grid search and the refine
+        step. Must be called after :meth:`read_models` so that
+        ``density_unit`` / ``radiation_field_unit`` are set.
+
+        Parameters
+        ----------
+        radiation_field_range : :class:`~astropy.units.Quantity`, sequence, or None
+            Allowed radiation field window; see :meth:`run`.
+        density_range : :class:`~astropy.units.Quantity`, sequence, or None
+            Allowed density window; see :meth:`run`.
+
+        Raises
+        ------
+        ValueError
+            If a range is malformed, has incompatible units, or does not
+            overlap the model grid.
+        """
+        fk = utils.firstkey(self._modelratios)
+        # linear (not log) physical axis values with units: x=density, y=radiation field
+        x, y = utils.get_xy_from_wcs(self._modelratios[fk], quantity=True, linear=True)
+        self._density_range = self._normalize_one_range(density_range, x, self.density_unit, "density_range")
+        self._radiation_field_range = self._normalize_one_range(
+            radiation_field_range, y, self.radiation_field_unit, "radiation_field_range"
+        )
+
+    @staticmethod
+    def _normalize_one_range(user_range, axis, unit, name):
+        """Normalize a single phase-space limit to ``(lower, upper)`` floats.
+
+        Parameters
+        ----------
+        user_range : :class:`~astropy.units.Quantity`, sequence, or None
+            The user-supplied range. A length-2 Quantity, or a length-2 sequence
+            whose elements are each ``None`` or a scalar Quantity. ``None`` (or a
+            ``None`` element) means no limit on that side.
+        axis : :class:`~astropy.units.Quantity`
+            The model grid axis values (linear, with units) for this parameter.
+        unit : :class:`~astropy.units.Unit`
+            The model's linear axis unit to convert the bounds into.
+        name : str
+            Keyword name, used in error messages.
+
+        Returns
+        -------
+        tuple of float
+            ``(lower, upper)`` in ``unit``, with grid extremes substituted for
+            unspecified bounds.
+        """
+        grid_min = float(np.min(axis.to(unit).value))
+        grid_max = float(np.max(axis.to(unit).value))
+        if user_range is None:
+            return None  # unrestricted
+        # Extract the two bounds, each a scalar Quantity or None.
+        if isinstance(user_range, u.Quantity):
+            if user_range.isscalar or len(user_range) != 2:
+                raise ValueError(f"{name} must have exactly two elements [lower, upper]")
+            bounds = [user_range[0], user_range[1]]
+        else:
+            try:
+                bounds = list(user_range)
+            except TypeError as err:
+                raise ValueError(f"{name} must be a length-2 Quantity or sequence [lower, upper]") from err
+            if len(bounds) != 2:
+                raise ValueError(f"{name} must have exactly two elements [lower, upper]")
+        limits = [grid_min, grid_max]  # defaults substituted for None bounds
+        for i, b in enumerate(bounds):
+            if b is None:
+                continue
+            if not isinstance(b, u.Quantity):
+                raise ValueError(
+                    f"{name} bounds must be astropy Quantities (with units); got {b!r}. For a one-sided limit put"
+                    " the unit inside the brackets, e.g. [None, 1e4/u.cm**3]."
+                )
+            try:
+                limits[i] = float(b.to(unit).value)
+            except u.UnitConversionError as err:
+                raise ValueError(f"{name} bound {b} is not convertible to model units ({unit})") from err
+        lo, hi = limits
+        if lo > hi:
+            raise ValueError(f"{name} lower bound ({lo}) exceeds upper bound ({hi})")
+        if hi < grid_min or lo > grid_max:
+            raise ValueError(
+                f"{name} [{lo}, {hi}] {unit} does not overlap the model grid coverage [{grid_min}, {grid_max}] {unit}"
+            )
+        return (lo, hi)
+
     def _check_compatibility(self):
         """Check that all Measurements are compatible (beams, coordinate systems, shapes) so that the computation can commence.
 
@@ -503,6 +600,21 @@ class LineRatioFit(ToolBase):
             - ``[‘error’, (low, high)]`` — mask where error pixel is below low or above high
             - ``None`` — no masking (default)
 
+        radiation_field_range : :class:`~astropy.units.Quantity` or sequence, optional
+            Restrict the fit to radiation field values within
+            ``[lower, upper]`` (inclusive), excluding unphysical regimes.
+            Accepts either a length-2 :class:`~astropy.units.Quantity`
+            (e.g. ``[100, 1000]*habing_unit``) or a length-2 sequence whose
+            elements are each ``None`` or a scalar
+            :class:`~astropy.units.Quantity` (e.g. ``[None, 1000*habing_unit]``
+            for an upper limit only). ``None`` on a side means no limit there.
+            Note the unit must be *inside* the brackets for a one-sided limit,
+            since ``None*unit`` is not allowed. Default: ``None`` (no restriction).
+        density_range : :class:`~astropy.units.Quantity` or sequence, optional
+            Restrict the fit to density values within ``[lower, upper]``
+            (inclusive). Same accepted forms as ``radiation_field_range``,
+            e.g. ``[1e3, 1e4]/u.cm**3`` or ``[None, 1e4/u.cm**3]``. ``None`` on
+            a side means no limit there. Default: ``None`` (no restriction).
         method : str, optional
             Fitting method. Default: ``’leastsq’`` (Levenberg-Marquardt). See
             https://lmfit-py.readthedocs.io/en/latest/fitting.html#fit-methods-table.
@@ -526,6 +638,10 @@ class LineRatioFit(ToolBase):
         Exception
             If no models match the input observations, observations are incompatible,
             parameters are unrecognized, or NaN is encountered.
+        ValueError
+            If ``radiation_field_range`` or ``density_range`` is malformed, has
+            the wrong units, or specifies a window that does not overlap the
+            model grid.
         """
         # @todo global masking for 'data', 'clip', 'error' not entirely useful unless all data/error have same ranges.
         # need something like ['data',['key1':(low,hi), 'key2',(low,hi),...], which is very complicated.
@@ -535,6 +651,9 @@ class LineRatioFit(ToolBase):
             "method": "leastsq",
             "nan_policy": "raise",
             "refine": True,
+            # phase-space limits (issue #236)
+            "radiation_field_range": None,
+            "density_range": None,
             # for emcee
             "burn": 0,
             "steps": 1000,
@@ -556,6 +675,10 @@ class LineRatioFit(ToolBase):
         self._check_compatibility()
         self._ratiocount = None
         self.read_models()
+        # Normalize and validate user phase-space limits now that model axis
+        # units/extents are known (read_models sets density_unit/radiation_field_unit).
+        # Raises ValueError up front if a range does not overlap the grid.
+        self._normalize_phase_space_limits(kwargs_opts.pop("radiation_field_range"), kwargs_opts.pop("density_range"))
         self._reset_masks()
         self._mask_measurements(kwargs_opts["mask"])
         kwargs_opts.pop("mask")
@@ -864,6 +987,15 @@ class LineRatioFit(ToolBase):
         maxn = x[-1]
         minfuv = y[0]
         maxfuv = y[-1]
+        # Clamp bounds to the user's phase-space window (issue #236). These four
+        # scalars feed the serial, parallel, and joint refine paths, so this
+        # single clamp restricts them all.
+        if self._density_range is not None:
+            minn = max(minn, self._density_range[0])
+            maxn = min(maxn, self._density_range[1])
+        if self._radiation_field_range is not None:
+            minfuv = max(minfuv, self._radiation_field_range[0])
+            maxfuv = min(maxfuv, self._radiation_field_range[1])
         if self._radiation_field is None or self._density is None:
             startn = x[int(len(x) / 2)]
             startfuv = y[int(len(y) / 2)]
@@ -1189,9 +1321,21 @@ class LineRatioFit(ToolBase):
             secondindex = 2
             thirdindex = 3
             fourthindex = 4
-        rchi_min = np.amin(self._reduced_chisq.data, (firstindex, secondindex))
-        chi_min = np.amin(self._chisq.data, (firstindex, secondindex))
-        gnxy = np.where(self._reduced_chisq == rchi_min)
+        # Restrict the coarse grid search to the allowed phase-space window
+        # (issue #236). Out-of-range model cells are set to +inf on local copies
+        # (the stored full chisq cubes are left untouched) so the argmin below
+        # is confined to the physical region. Validation in
+        # _normalize_phase_space_limits guarantees >=1 in-range cell survives.
+        allowed = self._phase_space_grid_mask(self._reduced_chisq.data.ndim, firstindex, secondindex)
+        if allowed is None:
+            masked_rchi = self._reduced_chisq.data
+            masked_chi = self._chisq.data
+        else:
+            masked_rchi = np.where(allowed, self._reduced_chisq.data, np.inf)
+            masked_chi = np.where(allowed, self._chisq.data, np.inf)
+        rchi_min = np.amin(masked_rchi, (firstindex, secondindex))
+        chi_min = np.amin(masked_chi, (firstindex, secondindex))
+        gnxy = np.where(masked_rchi == rchi_min)
         gi = gnxy[firstindex]
         ni = gnxy[secondindex]
         # spatial_idx is which indices are the spatial axes
@@ -1284,6 +1428,49 @@ class LineRatioFit(ToolBase):
         utils.setkey("BUNIT", f"Minimum Reduced Chi-squared (DOF={self._dof:d})", self._reduced_chisq_min)
         self._makehistory(self._reduced_chisq_min)
         self._makehistory(self._chisq_min)
+
+    def _phase_space_grid_mask(self, ndim, firstindex, secondindex):
+        """Boolean mask selecting model grid cells inside the allowed
+        phase-space window (issue #236), or ``None`` if unrestricted.
+
+        The returned array is broadcastable to the chi-squared cube: it is 1
+        along every axis except the radiation-field axis (``firstindex``) and
+        the density axis (``secondindex``).
+
+        Parameters
+        ----------
+        ndim : int
+            Number of dimensions of the chi-squared cube.
+        firstindex : int
+            Cube axis index of the radiation field.
+        secondindex : int
+            Cube axis index of the density.
+
+        Returns
+        -------
+        :class:`numpy.ndarray` of bool or None
+            ``None`` when no phase-space limits are active.
+        """
+        if self._density_range is None and self._radiation_field_range is None:
+            return None
+        fk = utils.firstkey(self._modelratios)
+        # linear physical axis values with units: x=density, y=radiation field
+        x, y = utils.get_xy_from_wcs(self._modelratios[fk], quantity=True, linear=True)
+        xden = x.to(self.density_unit).value  # values along secondindex
+        yrf = y.to(self.radiation_field_unit).value  # values along firstindex
+        den_ok = np.ones(len(xden), dtype=bool)
+        rf_ok = np.ones(len(yrf), dtype=bool)
+        if self._density_range is not None:
+            dlo, dhi = self._density_range
+            den_ok = (xden >= dlo) & (xden <= dhi)
+        if self._radiation_field_range is not None:
+            rlo, rhi = self._radiation_field_range
+            rf_ok = (yrf >= rlo) & (yrf <= rhi)
+        den_shape = [1] * ndim
+        den_shape[secondindex] = len(xden)
+        rf_shape = [1] * ndim
+        rf_shape[firstindex] = len(yrf)
+        return rf_ok.reshape(rf_shape) & den_ok.reshape(den_shape)
 
     def _makehistory(self, image):
         """Add HISTORY keyword indicating how density and radiation field were computed.

--- a/pdrtpy/tool/test/test_lineratiofit.py
+++ b/pdrtpy/tool/test/test_lineratiofit.py
@@ -2,6 +2,8 @@
 
 import os
 
+import astropy.units as u
+import numpy as np
 import pdrtpy.utils as utils
 import pytest
 from astropy.nddata import StdDevUncertainty
@@ -10,6 +12,9 @@ from pdrtpy.measurement import Measurement
 from pdrtpy.modelset import ModelSet
 from pdrtpy.tool.fitmap import FitMap
 from pdrtpy.tool.lineratiofit import LineRatioFit
+from pdrtpy.utils import habing_unit
+
+_CM3 = u.cm**3  # volume; [n] / _CM3 -> cm^-3, as written in issue #236
 
 # ---------------------------------------------------------------------------
 # Module-scoped fixtures
@@ -367,6 +372,115 @@ class TestRunMasking:
         # Should complete without error (mask is ignored with a warning)
         p.run(mask=["mad", 1.0])
         assert p.density is not None
+
+
+# ---------------------------------------------------------------------------
+# TestRunLimits  (phase-space limiting, issue #236)
+# ---------------------------------------------------------------------------
+
+
+class TestRunLimits:
+    def test_limit_around_best_fit_unchanged(self, single_pixel_fit, wk2020, single_pixel_measurements):
+        """A window that brackets the unrestricted best fit returns the same answer."""
+        n0 = float(single_pixel_fit.density.data.flatten()[0])
+        g0 = float(single_pixel_fit.radiation_field.data.flatten()[0])
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        p.run(
+            density_range=[n0 / 10, n0 * 10] / _CM3,
+            radiation_field_range=[g0 / 10, g0 * 10] * single_pixel_fit.radiation_field.unit,
+        )
+        assert float(p.density.data.flatten()[0]) == pytest.approx(n0, rel=0.05)
+        assert float(p.radiation_field.data.flatten()[0]) == pytest.approx(g0, rel=0.05)
+
+    def test_density_range_restricts_result(self, single_pixel_fit, wk2020, single_pixel_measurements):
+        """A window excluding the unrestricted minimum forces density into the window."""
+        n0 = float(single_pixel_fit.density.data.flatten()[0])
+        lo = 10 ** (np.log10(n0) + 1.0)
+        hi = 10 ** (np.log10(n0) + 2.0)
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        p.run(density_range=[lo, hi] / _CM3)
+        n = float(p.density.data.flatten()[0])
+        assert lo <= n <= hi
+        assert n > n0
+
+    def test_radiation_field_upper_limit_in_habing(self, single_pixel_fit, wk2020, single_pixel_measurements):
+        """One-sided upper limit given in Habing units on a cgs-unit model."""
+        rf_unit = single_pixel_fit.radiation_field.unit
+        g0_habing = (float(single_pixel_fit.radiation_field.data.flatten()[0]) * rf_unit).to(habing_unit).value
+        hi = g0_habing / 3.0
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        # None inside the brackets, unit on the scalar (issue #236 requirement)
+        p.run(radiation_field_range=[None, hi * habing_unit])
+        g = (float(p.radiation_field.data.flatten()[0]) * rf_unit).to(habing_unit).value
+        assert g <= hi * 1.0001
+
+    def test_density_lower_limit_only(self, single_pixel_fit, wk2020, single_pixel_measurements):
+        """One-sided lower limit with None on the upper side."""
+        n0 = float(single_pixel_fit.density.data.flatten()[0])
+        lo = 10 ** (np.log10(n0) + 1.0)
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        p.run(density_range=[lo / _CM3, None])
+        assert float(p.density.data.flatten()[0]) >= lo
+
+    def test_quantity_array_form_accepted(self, wk2020, single_pixel_measurements):
+        """Both [a, b]*unit and [a/unit, b/unit] forms are accepted."""
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        p.run(density_range=[1e3, 1e5] / _CM3, radiation_field_range=[10, 1000] * habing_unit)
+        assert p.density is not None
+        assert p.radiation_field is not None
+
+    def test_range_outside_grid_raises(self, wk2020, single_pixel_measurements):
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        with pytest.raises(ValueError, match=r"does not overlap the model grid"):
+            p.run(density_range=[1e12, 1e13] / _CM3)
+
+    def test_missing_unit_raises(self, wk2020, single_pixel_measurements):
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        with pytest.raises(ValueError, match=r"astropy Quantities"):
+            p.run(density_range=[None, 1e4])
+
+    def test_wrong_dimension_unit_raises(self, wk2020, single_pixel_measurements):
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        with pytest.raises(ValueError, match=r"not convertible to model units"):
+            p.run(density_range=[1e3, 1e4] * u.cm)  # length, not number density
+
+    def test_bad_length_raises(self, wk2020, single_pixel_measurements):
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        with pytest.raises(ValueError, match=r"exactly two elements"):
+            p.run(density_range=[1e3, 1e4, 1e5] / _CM3)
+
+    def test_lower_exceeds_upper_raises(self, wk2020, single_pixel_measurements):
+        p = LineRatioFit(wk2020, measurements=list(single_pixel_measurements))
+        with pytest.raises(ValueError, match=r"lower bound.*exceeds upper bound"):
+            p.run(density_range=[1e5, 1e3] / _CM3)
+
+    def test_map_fit_respects_limits(self, map_fit, smc_ms, map_measurements):
+        """Limits propagate through the default per-pixel map loop.
+
+        The SMC density grid spans 1e2..1e7 cm-3, and the unrestricted fit
+        (map_fit) puts several pixels above 1e5, so [1e3, 1e5] is a genuine
+        restriction. Verify some pixels are out of window unrestricted, and
+        none are once the limit is applied.
+        """
+        lo, hi = 1e3, 1e5
+        base = map_fit.density.data
+        base_finite = base[np.isfinite(base)]
+        assert np.any(base_finite > hi)  # the window actually excludes something
+
+        p = LineRatioFit(smc_ms, measurements=list(map_measurements))
+        p.run(density_range=[lo, hi] / _CM3)
+        finite = p.density.data[np.isfinite(p.density.data)]
+        assert len(finite) > 0
+        assert np.all((finite >= lo * 0.999) & (finite <= hi * 1.001))
+
+    def test_map_fit_joint_respects_limits(self, smc_ms, map_measurements):
+        """Limits also constrain the joint (scipy) fit path (joint_fit='fast')."""
+        lo, hi = 1e3, 1e5
+        p = LineRatioFit(smc_ms, measurements=list(map_measurements))
+        p.run(density_range=[lo, hi] / _CM3, joint_fit="fast")
+        finite = p.density.data[np.isfinite(p.density.data)]
+        assert len(finite) > 0
+        assert np.all((finite >= lo * 0.999) & (finite <= hi * 1.001))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #236.

Adds `radiation_field_range` and `density_range` keywords to `LineRatioFit.run()` so users can restrict the allowed radiation field (G0) and/or density (n) window and exclude unphysical minima when the data underconstrain the fit (see [Pound & Wolfire 2023](https://ui.adsabs.harvard.edu/abs/2023AJ....165...25P/abstract)).

## API

```python
from pdrtpy.utils import habing_unit
import astropy.units as u
cm3 = u.cm**3  # volume; [n] / cm3 -> cm^-3

p = LineRatioFit(ModelSet("wk2020", z=1), measurements=[...])
p.run(radiation_field_range=[100, 1000]*habing_unit,
      density_range=[None, 1e4/cm3])   # one-sided upper limit
```

Each keyword accepts either:
- a length-2 astropy `Quantity` — `[100, 1000]*habing_unit`, `[1e3, 1e4]/cm3`
- a length-2 sequence whose elements are each `None` or a scalar `Quantity` — `[None, 1e4/cm3]`, `[1e3/cm3, None]`

`None` means no limit on that side. For a one-sided limit the unit must sit **inside** the brackets on the scalar, since `None*unit` is not allowed. Bounds are given in any equivalent unit and converted to the model's linear axis units.

A `ValueError` is raised up front if a range is malformed, has the wrong units, is inverted, or does not overlap the model grid (the grid extent is fixed per `ModelSet`, so this is validated once before fitting).

## Implementation

The limit is applied in two places:
- **Coarse grid search** — out-of-range cells of the chi-squared grid are masked to `+inf` before the argmin, on local copies so the stored chisq cubes are untouched. This is the load-bearing change: it decides which of the (possibly degenerate) minima is selected.
- **Refine step** — the bounds `minn/maxn/minfuv/maxfuv` are clamped once, which propagates to the serial, parallel, and joint (`hybrid`/`fast`) fit paths.

## Tests

New `TestRunLimits` class (12 tests) covering the single-pixel serial path, the default map path, and `joint_fit="fast"`, plus every validation error case (out-of-grid, missing unit, wrong-dimension unit, bad length, inverted range). Full `pdrtpy/tool/test` suite passes (94 passed), including the `test_against_scipy` regression.

## Follow-up

#237 tracks shading the excluded phase-space region in `LineRatioPlot` (visualization only; the returned chi-squared cubes are intentionally left unmasked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
